### PR TITLE
feat: sync command implementation is complete

### DIFF
--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 17.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -15,6 +15,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash
+
     strategy:
       matrix:
         node-version: [16.x, 17.x, 18.x]
@@ -34,4 +38,3 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "<>"
       - run: npm run test:ci
-        shell: bash

--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -28,4 +28,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
+      # https://ao.ms/how-to-use-git-commit-in-github-actions/
+      - name: setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
       - run: npm run test:ci

--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 17.x, 18.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -34,3 +34,4 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "<>"
       - run: npm run test:ci
+        shell: bash

--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -37,4 +37,5 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "<>"
+          git config --global init.defaultBranch main
       - run: npm run test:ci

--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -28,4 +28,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
+      # https://ao.ms/how-to-use-git-commit-in-github-actions/
+      - name: setup git config
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "<>"
       - run: npm run test:ci

--- a/.github/workflows/dotfilers.yml
+++ b/.github/workflows/dotfilers.yml
@@ -28,9 +28,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
-      # https://ao.ms/how-to-use-git-commit-in-github-actions/
-      - name: setup git config
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
       - run: npm run test:ci

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "RNEA",
     "spicetify",
     "tilix",
+    "Vals",
     "webcompat"
   ],
   "jest.autoRun": "off"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "postbuild",
     "readdirp",
     "RNEA",
+    "simplegit",
     "spicetify",
     "tilix",
     "Vals",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,7 @@
-import type { Config } from '@jest/types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { defaults } from 'jest-config';
+
+import type { Config } from '@jest/types';
 
 const areWeTestingLibs = process.env?.FOR_LIB ?? false;
 const isCI = process.env?.CI ?? false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "boxen": "^7.0.0",
         "fast-glob": "^3.2.12",
-        "fp-ts": "^2.12.3",
-        "io-ts": "^2.2.18",
+        "fp-ts": "^2.13.1",
+        "io-ts": "^2.2.19",
         "is-glob": "^4.0.3",
         "micromatch": "^4.0.5",
         "monocle-ts": "^2.3.13",
@@ -22,25 +22,25 @@
         "readdirp": "^3.6.0",
         "simple-git": "^3.14.1",
         "ts-pattern": "^4.0.5",
-        "zx": "^7.0.8"
+        "zx": "^7.1.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
-        "@jest/globals": "^29.0.2",
+        "@jest/globals": "^29.2.1",
         "@jest/types": "^28.1.3",
         "@types/boxen": "^3.0.1",
         "@types/eslint-config-prettier": "^6.11.0",
         "@types/is-glob": "^4.0.2",
         "@types/jest": "^28.1.8",
         "@types/micromatch": "^4.0.2",
-        "@types/node": "^18.7.16",
+        "@types/node": "^18.11.0",
         "@types/ora": "^3.2.0",
-        "@types/prompts": "^2.0.14",
-        "@types/ramda": "^0.28.15",
-        "@typescript-eslint/eslint-plugin": "^5.36.2",
-        "@typescript-eslint/parser": "^5.36.2",
-        "eslint": "^8.23.0",
+        "@types/prompts": "^2.4.1",
+        "@types/ramda": "^0.28.16",
+        "@typescript-eslint/eslint-plugin": "^5.40.1",
+        "@typescript-eslint/parser": "^5.40.1",
+        "eslint": "^8.25.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^3.5.1",
@@ -55,7 +55,7 @@
         "ts-jest": "^28.0.8",
         "ts-node": "^10.9.1",
         "tsc-alias": "^1.7.0",
-        "typescript": "^4.8.3"
+        "typescript": "^4.8.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -977,9 +977,9 @@
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -988,16 +988,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1544,24 +1534,24 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.0.2.tgz",
-      "integrity": "sha512-Yf+EYaLOrVCgts/aTS5nGznU4prZUPa5k9S63Yct8YSOKj2jkdS17hHSUKhk5jxDFMyCy1PXknypDw7vfgc/mA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.2.1.tgz",
+      "integrity": "sha512-EutqA7T/X6zFjw6mAWRHND+ZkTPklmIEWCNbmwX6uCmOrFrWaLbDZjA+gePHJx6fFMMRvNfjXcvzXEtz54KPlg==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.0.2",
-        "@jest/types": "^29.0.2",
+        "@jest/fake-timers": "^29.2.1",
+        "@jest/types": "^29.2.1",
         "@types/node": "*",
-        "jest-mock": "^29.0.2"
+        "jest-mock": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/environment/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -1576,51 +1566,51 @@
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.0.2.tgz",
-      "integrity": "sha512-y/3geZ92p2/zovBm/F+ZjXUJ3thvT9IRzD6igqaWskFE2aR0idD+N/p5Lj/ZautEox/9RwEc6nqergebeh72uQ==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.2.1.tgz",
+      "integrity": "sha512-o14R2t2tHHHudwji43UKkzmmH49xfF5T++FQBK2tl88qwuBWQOcx7fNUYl+mA/9TPNAN0FkQ3usnpyS8FUwsvQ==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.0.2",
-        "jest-snapshot": "^29.0.2"
+        "expect": "^29.2.1",
+        "jest-snapshot": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.0.2.tgz",
-      "integrity": "sha512-+wcQF9khXKvAEi8VwROnCWWmHfsJYCZAs5dmuMlJBKk57S6ZN2/FQMIlo01F29fJyT8kV/xblE7g3vkIdTLOjw==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.2.1.tgz",
+      "integrity": "sha512-yr4aHNg5Z1CjKby5ozm7sKjgBlCOorlAoFcvrOQ/4rbZRfgZQdnmh7cth192PYIgiPZo2bBXvqdOApnAMWFJZg==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.0.0"
+        "jest-get-type": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.0.2.tgz",
-      "integrity": "sha512-2JhQeWU28fvmM5r33lxg6BxxkTKaVXs6KMaJ6eXSM8ml/MaWkt2BvbIO8G9KWAJFMdBXWbn+2h9OK1/s5urKZA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.2.1.tgz",
+      "integrity": "sha512-KWil+8fef7Uj/P/PTZlPKk1Pw117wAmr71VWFV8ZDtRtkwmTG8oY4IRf0Ss44J2y5CYRy8d/zLOhxyoGRENjvA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@sinonjs/fake-timers": "^9.1.2",
         "@types/node": "*",
-        "jest-message-util": "^29.0.2",
-        "jest-mock": "^29.0.2",
-        "jest-util": "^29.0.2"
+        "jest-message-util": "^29.2.1",
+        "jest-mock": "^29.2.1",
+        "jest-util": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -1635,24 +1625,24 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.0.2.tgz",
-      "integrity": "sha512-4hcooSNJCVXuTu07/VJwCWW6HTnjLtQdqlcGisK6JST7z2ixa8emw4SkYsOk7j36WRc2ZUEydlUePnOIOTCNXg==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.2.1.tgz",
+      "integrity": "sha512-Z4EejYPP1OPVq2abk1+9urAwJqkgw5jB2UJGlPjb5ZwzPQF8WLMcigKEfFzZb2OHhEVPP0RZD0/DbVTY1R6iQA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.0.2",
-        "@jest/expect": "^29.0.2",
-        "@jest/types": "^29.0.2",
-        "jest-mock": "^29.0.2"
+        "@jest/environment": "^29.2.1",
+        "@jest/expect": "^29.2.1",
+        "@jest/types": "^29.2.1",
+        "jest-mock": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -2012,22 +2002,22 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.2.tgz",
-      "integrity": "sha512-lajVQx2AnsR+Pa17q2zR7eikz2PkPs1+g/qPbZkqQATeS/s6eT55H+yHcsLfuI/0YQ/4VSBepSu3bOX+44q0aA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.2.1.tgz",
+      "integrity": "sha512-xup+iEuaIRSQabQaeqxaQyN0vg1Dctrp9oTObQsNf3sZEowTIa5cANYuoyi8Tqhg4GCqEVLTf18KW7ii0UeFVA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.2",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.2",
+        "jest-haste-map": "^29.2.1",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.1",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -2038,9 +2028,9 @@
       }
     },
     "node_modules/@jest/transform/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -2542,9 +2532,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2575,9 +2565,9 @@
       "dev": true
     },
     "node_modules/@types/prompts": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
-      "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.1.tgz",
+      "integrity": "sha512-1Mqzhzi9W5KlooNE4o0JwSXGUDeQXKldbGn9NO4tpxwZbHXYd+WcKpCksG2lbhH7U9I9LigfsdVsP2QAY0lNPA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2589,13 +2579,19 @@
       "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw=="
     },
     "node_modules/@types/ramda": {
-      "version": "0.28.15",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.15.tgz",
-      "integrity": "sha512-FCaLNVZry65jW8x/FDnKgjgkCNQxgc5AYMQwdNn6yW5M+62R+0nt2Y36U43dTNora9hcquemfrY5gxhE5pcilQ==",
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.16.tgz",
+      "integrity": "sha512-dxx0V3/thotNhkHjBL5ifkXm9Cj3aANnAcEjMuGq2i5OaznWaiyGAQR9CicO7fJrFXg6KSoeuKmc+akItd0Fww==",
       "dev": true,
       "dependencies": {
         "ts-toolbelt": "^6.15.1"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2624,16 +2620,15 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
-      "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
+      "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/type-utils": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/type-utils": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -2657,14 +2652,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
-      "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
+      "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2684,13 +2679,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
-      "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.1.tgz",
+      "integrity": "sha512-jkn4xsJiUQucI16OLCXrLRXDZ3afKhOIqXs4R3O+M00hdQLKR58WuyXPZZjhKLFCEP2g+TXdBRtLQ33UfAdRUg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2"
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2701,13 +2696,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
-      "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.1.tgz",
+      "integrity": "sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2728,9 +2723,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-      "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.1.tgz",
+      "integrity": "sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2741,13 +2736,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
-      "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.1.tgz",
+      "integrity": "sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2768,17 +2763,19 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
-      "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.1.tgz",
+      "integrity": "sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2792,12 +2789,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
-      "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.1.tgz",
+      "integrity": "sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/types": "5.40.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3941,9 +3938,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
-      "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.2.0.tgz",
+      "integrity": "sha512-413SY5JpYeSBZxmenGEmCVQ8mCgtFJF0w9PROdaS6z987XC2Pd2GOKqOITLtMftmyFZqgtCOb/QA7/Z3ZXfzIw==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4124,14 +4121,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.1",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -4148,7 +4144,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -4157,6 +4152,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -4661,16 +4657,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.0.2.tgz",
-      "integrity": "sha512-JeJlAiLKn4aApT4pzUXBVxl3NaZidWIOdg//smaIlP9ZMBDkHZGFd9ubphUZP9pUyDEo7bC6M0IIZR51o75qQw==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.2.1.tgz",
+      "integrity": "sha512-BJtA754Fba0YWRWHgjKUMTA3ltWarKgITXHQnbZ2mTxTXC4yMQlR0FI7HkB3fJYkhWBf4qjNiqvg3LDtXCcVRQ==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.0.2",
-        "jest-get-type": "^29.0.0",
-        "jest-matcher-utils": "^29.0.2",
-        "jest-message-util": "^29.0.2",
-        "jest-util": "^29.0.2"
+        "@jest/expect-utils": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "jest-matcher-utils": "^29.2.1",
+        "jest-message-util": "^29.2.1",
+        "jest-util": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4829,9 +4825,9 @@
       }
     },
     "node_modules/fp-ts": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.3.tgz",
-      "integrity": "sha512-8m0XvW8kZbfnJOA4NvSVXu95mLbPf4LQGwQyqVukIYS4KzSNJiyKSmuZUmbVHteUi6MGkAJGPb0goPZqI+Tsqg=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.13.1.tgz",
+      "integrity": "sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ=="
     },
     "node_modules/from": {
       "version": "0.1.7",
@@ -4894,12 +4890,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -5372,9 +5362,9 @@
       }
     },
     "node_modules/io-ts": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.18.tgz",
-      "integrity": "sha512-3JxUUzRtPQPs5sOwB7pW0+Xb54nOzqA6M1sRB1hwgsRmkWMeGTjtOrCynGTJhIj+mBLUj2S37DAq2+BrPh9kTQ==",
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.19.tgz",
+      "integrity": "sha512-ED0GQwvKRr5C2jqOOJCkuJW2clnbzqFexQ8V7Qsb+VB36S1Mk/OKH7k0FjSe4mjKy9qBRA3OqgVGyFMUEKIubw==",
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -6349,15 +6339,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.0.2.tgz",
-      "integrity": "sha512-b9l9970sa1rMXH1owp2Woprmy42qIwwll/htsw4Gf7+WuSp5bZxNhkKHDuCGKL+HoHn1KhcC+tNEeAPYBkD2Jg==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.2.1.tgz",
+      "integrity": "sha512-gfh/SMNlQmP3MOUgdzxPOd4XETDJifADpT937fN1iUGz+9DgOu2eUPHH25JDkLVcLwwqxv3GzVyK4VBUr9fjfA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.0.0",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.2"
+        "diff-sequences": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6611,29 +6601,29 @@
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
-      "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.2.tgz",
-      "integrity": "sha512-SOorh2ysQ0fe8gsF4gaUDhoMIWAvi2hXOkwThEO48qT3JqA8GLAUieQcIvdSEd6M0scRDe1PVmKc5tXR3Z0U0A==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.2.1.tgz",
+      "integrity": "sha512-wF460rAFmYc6ARcCFNw4MbGYQjYkvjovb9GBT+W10Um8q5nHq98jD6fHZMDMO3tA56S8XnmNkM8GcA8diSZfnA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.2",
-        "jest-worker": "^29.0.2",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.1",
+        "jest-worker": "^29.2.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -6645,9 +6635,9 @@
       }
     },
     "node_modules/jest-haste-map/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -6723,33 +6713,33 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.0.2.tgz",
-      "integrity": "sha512-s62YkHFBfAx0JLA2QX1BlnCRFwHRobwAv2KP1+YhjzF6ZCbCVrf1sG8UJyn62ZUsDaQKpoo86XMTjkUyO5aWmQ==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.1.tgz",
+      "integrity": "sha512-hUTBh7H/Mnb6GTpihbLh8uF5rjAMdekfW/oZNXUMAXi7bbmym2HiRpzgqf/zzkjgejMrVAkPdVSQj+32enlUww==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.0.2",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.2"
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.0.2.tgz",
-      "integrity": "sha512-kcJAgms3ckJV0wUoLsAM40xAhY+pb9FVSZwicjFU9PFkaTNmqh9xd99/CzKse48wPM1ANUQKmp03/DpkY+lGrA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.2.1.tgz",
+      "integrity": "sha512-Dx5nEjw9V8C1/Yj10S/8ivA8F439VS8vTq1L7hEgwHFn9ovSKNpYW/kwNh7UglaEgXO42XxzKJB+2x0nSglFVw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.0.2",
+        "pretty-format": "^29.2.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -6758,9 +6748,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -6775,22 +6765,23 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.0.2.tgz",
-      "integrity": "sha512-giWXOIT23UCxHCN2VUfUJ0Q7SmiqQwfSFXlCaIhW5anITpNQ+3vuLPQdKt5wkuwM37GrbFyHIClce8AAK9ft9g==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.2.1.tgz",
+      "integrity": "sha512-NDphaY/GqyQpTfnTZiTqqpMaw4Z0I7XnB7yBgrT6IwYrLGxpOhrejYr4ANY4YvO2sEGdd8Tx/6D0+WLQy7/qDA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.2",
-        "@types/node": "*"
+        "@jest/types": "^29.2.1",
+        "@types/node": "*",
+        "jest-util": "^29.2.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-mock/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -6822,9 +6813,9 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
-      "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.2.0.tgz",
+      "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7841,9 +7832,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.0.2.tgz",
-      "integrity": "sha512-26C4PzGKaX5gkoKg8UzYGVy2HPVcTaROSkf0gwnHu3lGeTB7bAIJBovvVPZoiJ20IximJELQs/r8WSDRCuGX2A==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.2.1.tgz",
+      "integrity": "sha512-KZdLD7iEz5M4ZYd+ezZ/kk73z+DtNbk/yJ4Qx7408Vb0CCuclJIZPa/HmIwSsCfIlOBNcYTKufr7x/Yv47oYlg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -7852,23 +7843,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.0.2",
-        "@jest/transform": "^29.0.2",
-        "@jest/types": "^29.0.2",
+        "@jest/expect-utils": "^29.2.1",
+        "@jest/transform": "^29.2.1",
+        "@jest/types": "^29.2.1",
         "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.0.2",
+        "expect": "^29.2.1",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.0.2",
-        "jest-get-type": "^29.0.0",
-        "jest-haste-map": "^29.0.2",
-        "jest-matcher-utils": "^29.0.2",
-        "jest-message-util": "^29.0.2",
-        "jest-util": "^29.0.2",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "jest-haste-map": "^29.2.1",
+        "jest-matcher-utils": "^29.2.1",
+        "jest-message-util": "^29.2.1",
+        "jest-util": "^29.2.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.0.2",
+        "pretty-format": "^29.2.1",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -7876,9 +7867,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -7893,12 +7884,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.2.tgz",
-      "integrity": "sha512-ozk8ruEEEACxqpz0hN9UOgtPZS0aN+NffwQduR5dVlhN+eN47vxurtvgZkYZYMpYrsmlAEx1XabkB3BnN0GfKQ==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.2.1.tgz",
+      "integrity": "sha512-P5VWDj25r7kj7kl4pN2rG/RN2c1TLfYYYZYULnS/35nFDjBai+hBeo3MDrYZS7p6IoY3YHZnt2vq4L6mKnLk0g==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -7910,9 +7901,9 @@
       }
     },
     "node_modules/jest-util/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+      "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -8040,12 +8031,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.2.tgz",
-      "integrity": "sha512-EyvBlYcvd2pg28yg5A3OODQnqK9LI1kitnGUZUG5/NYIeaRgewtYBKB5wlr7oXj8zPCkzev7EmnTCsrXK7V+Xw==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.2.1.tgz",
+      "integrity": "sha512-ROHTZ+oj7sBrgtv46zZ84uWky71AoYi0vEV9CdEtc1FQunsoAGe5HbQmW76nI5QWdvECVPrSi1MCVUmizSavMg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
+        "jest-util": "^29.2.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -8067,6 +8059,12 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -8498,9 +8496,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
-      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -9000,9 +8998,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.0.2.tgz",
-      "integrity": "sha512-wp3CdtUa3cSJVFn3Miu5a1+pxc1iPIQTenOAn+x5erXeN1+ryTcLesV5pbK/rlW5EKwp27x38MoYfNGaNXDDhg==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.2.1.tgz",
+      "integrity": "sha512-Y41Sa4aLCtKAXvwuIpTvcFBkyeYp2gdFWzXGA+ZNES3VwURIB165XO/z7CjETwzCCS53MjW/rLMyyqEnTtaOfA==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -10237,9 +10235,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10602,20 +10600,20 @@
       }
     },
     "node_modules/zx": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.8.tgz",
-      "integrity": "sha512-sNjfDHzskqrSkWNj0TVhaowVK5AbpvuyuO1RBU4+LrFcgYI5u9CtyWWgUBRtRZl3bgGEF31zByszoBmwS47d1w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.1.1.tgz",
+      "integrity": "sha512-5YlTO2AJ+Ku2YuZKSSSqnUKuagcM/f/j4LmHs15O84Ch80Z9gzR09ZK3gR7GV+rc8IFpz2H/XNFtFVmj31yrZA==",
       "dependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/minimist": "^1.2.2",
-        "@types/node": "^18.6.3",
+        "@types/node": "^18.7.20",
         "@types/ps-tree": "^1.1.2",
         "@types/which": "^2.0.1",
         "chalk": "^5.0.1",
         "fs-extra": "^10.1.0",
         "globby": "^13.1.2",
         "minimist": "^1.2.6",
-        "node-fetch": "3.2.8",
+        "node-fetch": "3.2.10",
         "ps-tree": "^1.2.0",
         "which": "^2.0.2",
         "yaml": "^2.1.1"
@@ -11351,9 +11349,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -11388,21 +11386,15 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       }
-    },
-    "@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -11829,21 +11821,21 @@
       }
     },
     "@jest/environment": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.0.2.tgz",
-      "integrity": "sha512-Yf+EYaLOrVCgts/aTS5nGznU4prZUPa5k9S63Yct8YSOKj2jkdS17hHSUKhk5jxDFMyCy1PXknypDw7vfgc/mA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.2.1.tgz",
+      "integrity": "sha512-EutqA7T/X6zFjw6mAWRHND+ZkTPklmIEWCNbmwX6uCmOrFrWaLbDZjA+gePHJx6fFMMRvNfjXcvzXEtz54KPlg==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^29.0.2",
-        "@jest/types": "^29.0.2",
+        "@jest/fake-timers": "^29.2.1",
+        "@jest/types": "^29.2.1",
         "@types/node": "*",
-        "jest-mock": "^29.0.2"
+        "jest-mock": "^29.2.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -11857,42 +11849,42 @@
       }
     },
     "@jest/expect": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.0.2.tgz",
-      "integrity": "sha512-y/3geZ92p2/zovBm/F+ZjXUJ3thvT9IRzD6igqaWskFE2aR0idD+N/p5Lj/ZautEox/9RwEc6nqergebeh72uQ==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.2.1.tgz",
+      "integrity": "sha512-o14R2t2tHHHudwji43UKkzmmH49xfF5T++FQBK2tl88qwuBWQOcx7fNUYl+mA/9TPNAN0FkQ3usnpyS8FUwsvQ==",
       "dev": true,
       "requires": {
-        "expect": "^29.0.2",
-        "jest-snapshot": "^29.0.2"
+        "expect": "^29.2.1",
+        "jest-snapshot": "^29.2.1"
       }
     },
     "@jest/expect-utils": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.0.2.tgz",
-      "integrity": "sha512-+wcQF9khXKvAEi8VwROnCWWmHfsJYCZAs5dmuMlJBKk57S6ZN2/FQMIlo01F29fJyT8kV/xblE7g3vkIdTLOjw==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.2.1.tgz",
+      "integrity": "sha512-yr4aHNg5Z1CjKby5ozm7sKjgBlCOorlAoFcvrOQ/4rbZRfgZQdnmh7cth192PYIgiPZo2bBXvqdOApnAMWFJZg==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^29.0.0"
+        "jest-get-type": "^29.2.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.0.2.tgz",
-      "integrity": "sha512-2JhQeWU28fvmM5r33lxg6BxxkTKaVXs6KMaJ6eXSM8ml/MaWkt2BvbIO8G9KWAJFMdBXWbn+2h9OK1/s5urKZA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.2.1.tgz",
+      "integrity": "sha512-KWil+8fef7Uj/P/PTZlPKk1Pw117wAmr71VWFV8ZDtRtkwmTG8oY4IRf0Ss44J2y5CYRy8d/zLOhxyoGRENjvA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@sinonjs/fake-timers": "^9.1.2",
         "@types/node": "*",
-        "jest-message-util": "^29.0.2",
-        "jest-mock": "^29.0.2",
-        "jest-util": "^29.0.2"
+        "jest-message-util": "^29.2.1",
+        "jest-mock": "^29.2.1",
+        "jest-util": "^29.2.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -11906,21 +11898,21 @@
       }
     },
     "@jest/globals": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.0.2.tgz",
-      "integrity": "sha512-4hcooSNJCVXuTu07/VJwCWW6HTnjLtQdqlcGisK6JST7z2ixa8emw4SkYsOk7j36WRc2ZUEydlUePnOIOTCNXg==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.2.1.tgz",
+      "integrity": "sha512-Z4EejYPP1OPVq2abk1+9urAwJqkgw5jB2UJGlPjb5ZwzPQF8WLMcigKEfFzZb2OHhEVPP0RZD0/DbVTY1R6iQA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.0.2",
-        "@jest/expect": "^29.0.2",
-        "@jest/types": "^29.0.2",
-        "jest-mock": "^29.0.2"
+        "@jest/environment": "^29.2.1",
+        "@jest/expect": "^29.2.1",
+        "@jest/types": "^29.2.1",
+        "jest-mock": "^29.2.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -12202,22 +12194,22 @@
       }
     },
     "@jest/transform": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.2.tgz",
-      "integrity": "sha512-lajVQx2AnsR+Pa17q2zR7eikz2PkPs1+g/qPbZkqQATeS/s6eT55H+yHcsLfuI/0YQ/4VSBepSu3bOX+44q0aA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.2.1.tgz",
+      "integrity": "sha512-xup+iEuaIRSQabQaeqxaQyN0vg1Dctrp9oTObQsNf3sZEowTIa5cANYuoyi8Tqhg4GCqEVLTf18KW7ii0UeFVA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.2",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.2",
+        "jest-haste-map": "^29.2.1",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.1",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -12225,9 +12217,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -12665,9 +12657,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "@types/node": {
-      "version": "18.7.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -12697,9 +12689,9 @@
       "dev": true
     },
     "@types/prompts": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
-      "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.1.tgz",
+      "integrity": "sha512-1Mqzhzi9W5KlooNE4o0JwSXGUDeQXKldbGn9NO4tpxwZbHXYd+WcKpCksG2lbhH7U9I9LigfsdVsP2QAY0lNPA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -12711,13 +12703,19 @@
       "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw=="
     },
     "@types/ramda": {
-      "version": "0.28.15",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.15.tgz",
-      "integrity": "sha512-FCaLNVZry65jW8x/FDnKgjgkCNQxgc5AYMQwdNn6yW5M+62R+0nt2Y36U43dTNora9hcquemfrY5gxhE5pcilQ==",
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.16.tgz",
+      "integrity": "sha512-dxx0V3/thotNhkHjBL5ifkXm9Cj3aANnAcEjMuGq2i5OaznWaiyGAQR9CicO7fJrFXg6KSoeuKmc+akItd0Fww==",
       "dev": true,
       "requires": {
         "ts-toolbelt": "^6.15.1"
       }
+    },
+    "@types/semver": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -12746,16 +12744,15 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
-      "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
+      "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/type-utils": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/type-utils": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -12763,53 +12760,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
-      "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
+      "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
-      "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.1.tgz",
+      "integrity": "sha512-jkn4xsJiUQucI16OLCXrLRXDZ3afKhOIqXs4R3O+M00hdQLKR58WuyXPZZjhKLFCEP2g+TXdBRtLQ33UfAdRUg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2"
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
-      "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.1.tgz",
+      "integrity": "sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-      "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.1.tgz",
+      "integrity": "sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
-      "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.1.tgz",
+      "integrity": "sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -12818,26 +12815,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
-      "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.1.tgz",
+      "integrity": "sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
-      "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.1.tgz",
+      "integrity": "sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/types": "5.40.1",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -13659,9 +13658,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
-      "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.2.0.tgz",
+      "integrity": "sha512-413SY5JpYeSBZxmenGEmCVQ8mCgtFJF0w9PROdaS6z987XC2Pd2GOKqOITLtMftmyFZqgtCOb/QA7/Z3ZXfzIw==",
       "dev": true
     },
     "dir-glob": {
@@ -13800,14 +13799,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.1",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -13824,7 +13822,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -13833,6 +13830,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -14203,16 +14201,16 @@
       "dev": true
     },
     "expect": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.0.2.tgz",
-      "integrity": "sha512-JeJlAiLKn4aApT4pzUXBVxl3NaZidWIOdg//smaIlP9ZMBDkHZGFd9ubphUZP9pUyDEo7bC6M0IIZR51o75qQw==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.2.1.tgz",
+      "integrity": "sha512-BJtA754Fba0YWRWHgjKUMTA3ltWarKgITXHQnbZ2mTxTXC4yMQlR0FI7HkB3fJYkhWBf4qjNiqvg3LDtXCcVRQ==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^29.0.2",
-        "jest-get-type": "^29.0.0",
-        "jest-matcher-utils": "^29.0.2",
-        "jest-message-util": "^29.0.2",
-        "jest-util": "^29.0.2"
+        "@jest/expect-utils": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "jest-matcher-utils": "^29.2.1",
+        "jest-message-util": "^29.2.1",
+        "jest-util": "^29.2.1"
       }
     },
     "fast-deep-equal": {
@@ -14333,9 +14331,9 @@
       }
     },
     "fp-ts": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.3.tgz",
-      "integrity": "sha512-8m0XvW8kZbfnJOA4NvSVXu95mLbPf4LQGwQyqVukIYS4KzSNJiyKSmuZUmbVHteUi6MGkAJGPb0goPZqI+Tsqg=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.13.1.tgz",
+      "integrity": "sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ=="
     },
     "from": {
       "version": "0.1.7",
@@ -14382,12 +14380,6 @@
         "es-abstract": "^1.19.0",
         "functions-have-names": "^1.2.2"
       }
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
     },
     "functions-have-names": {
       "version": "1.2.3",
@@ -14712,9 +14704,9 @@
       }
     },
     "io-ts": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.18.tgz",
-      "integrity": "sha512-3JxUUzRtPQPs5sOwB7pW0+Xb54nOzqA6M1sRB1hwgsRmkWMeGTjtOrCynGTJhIj+mBLUj2S37DAq2+BrPh9kTQ==",
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.19.tgz",
+      "integrity": "sha512-ED0GQwvKRr5C2jqOOJCkuJW2clnbzqFexQ8V7Qsb+VB36S1Mk/OKH7k0FjSe4mjKy9qBRA3OqgVGyFMUEKIubw==",
       "requires": {}
     },
     "is-arrayish": {
@@ -15416,15 +15408,15 @@
       }
     },
     "jest-diff": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.0.2.tgz",
-      "integrity": "sha512-b9l9970sa1rMXH1owp2Woprmy42qIwwll/htsw4Gf7+WuSp5bZxNhkKHDuCGKL+HoHn1KhcC+tNEeAPYBkD2Jg==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.2.1.tgz",
+      "integrity": "sha512-gfh/SMNlQmP3MOUgdzxPOd4XETDJifADpT937fN1iUGz+9DgOu2eUPHH25JDkLVcLwwqxv3GzVyK4VBUr9fjfA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.0.0",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.2"
+        "diff-sequences": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
       }
     },
     "jest-docblock": {
@@ -15619,35 +15611,35 @@
       }
     },
     "jest-get-type": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
-      "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.2.tgz",
-      "integrity": "sha512-SOorh2ysQ0fe8gsF4gaUDhoMIWAvi2hXOkwThEO48qT3JqA8GLAUieQcIvdSEd6M0scRDe1PVmKc5tXR3Z0U0A==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.2.1.tgz",
+      "integrity": "sha512-wF460rAFmYc6ARcCFNw4MbGYQjYkvjovb9GBT+W10Um8q5nHq98jD6fHZMDMO3tA56S8XnmNkM8GcA8diSZfnA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.2",
-        "jest-worker": "^29.0.2",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.1",
+        "jest-worker": "^29.2.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -15706,38 +15698,38 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.0.2.tgz",
-      "integrity": "sha512-s62YkHFBfAx0JLA2QX1BlnCRFwHRobwAv2KP1+YhjzF6ZCbCVrf1sG8UJyn62ZUsDaQKpoo86XMTjkUyO5aWmQ==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.1.tgz",
+      "integrity": "sha512-hUTBh7H/Mnb6GTpihbLh8uF5rjAMdekfW/oZNXUMAXi7bbmym2HiRpzgqf/zzkjgejMrVAkPdVSQj+32enlUww==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.0.2",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.2"
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
       }
     },
     "jest-message-util": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.0.2.tgz",
-      "integrity": "sha512-kcJAgms3ckJV0wUoLsAM40xAhY+pb9FVSZwicjFU9PFkaTNmqh9xd99/CzKse48wPM1ANUQKmp03/DpkY+lGrA==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.2.1.tgz",
+      "integrity": "sha512-Dx5nEjw9V8C1/Yj10S/8ivA8F439VS8vTq1L7hEgwHFn9ovSKNpYW/kwNh7UglaEgXO42XxzKJB+2x0nSglFVw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.0.2",
+        "pretty-format": "^29.2.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -15751,19 +15743,20 @@
       }
     },
     "jest-mock": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.0.2.tgz",
-      "integrity": "sha512-giWXOIT23UCxHCN2VUfUJ0Q7SmiqQwfSFXlCaIhW5anITpNQ+3vuLPQdKt5wkuwM37GrbFyHIClce8AAK9ft9g==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.2.1.tgz",
+      "integrity": "sha512-NDphaY/GqyQpTfnTZiTqqpMaw4Z0I7XnB7yBgrT6IwYrLGxpOhrejYr4ANY4YvO2sEGdd8Tx/6D0+WLQy7/qDA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.2",
-        "@types/node": "*"
+        "@jest/types": "^29.2.1",
+        "@types/node": "*",
+        "jest-util": "^29.2.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -15784,9 +15777,9 @@
       "requires": {}
     },
     "jest-regex-util": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
-      "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.2.0.tgz",
+      "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
       "dev": true
     },
     "jest-resolve": {
@@ -16596,9 +16589,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.0.2.tgz",
-      "integrity": "sha512-26C4PzGKaX5gkoKg8UzYGVy2HPVcTaROSkf0gwnHu3lGeTB7bAIJBovvVPZoiJ20IximJELQs/r8WSDRCuGX2A==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.2.1.tgz",
+      "integrity": "sha512-KZdLD7iEz5M4ZYd+ezZ/kk73z+DtNbk/yJ4Qx7408Vb0CCuclJIZPa/HmIwSsCfIlOBNcYTKufr7x/Yv47oYlg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -16607,30 +16600,30 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.0.2",
-        "@jest/transform": "^29.0.2",
-        "@jest/types": "^29.0.2",
+        "@jest/expect-utils": "^29.2.1",
+        "@jest/transform": "^29.2.1",
+        "@jest/types": "^29.2.1",
         "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.0.2",
+        "expect": "^29.2.1",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.0.2",
-        "jest-get-type": "^29.0.0",
-        "jest-haste-map": "^29.0.2",
-        "jest-matcher-utils": "^29.0.2",
-        "jest-message-util": "^29.0.2",
-        "jest-util": "^29.0.2",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "jest-haste-map": "^29.2.1",
+        "jest-matcher-utils": "^29.2.1",
+        "jest-message-util": "^29.2.1",
+        "jest-util": "^29.2.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.0.2",
+        "pretty-format": "^29.2.1",
         "semver": "^7.3.5"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -16644,12 +16637,12 @@
       }
     },
     "jest-util": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.2.tgz",
-      "integrity": "sha512-ozk8ruEEEACxqpz0hN9UOgtPZS0aN+NffwQduR5dVlhN+eN47vxurtvgZkYZYMpYrsmlAEx1XabkB3BnN0GfKQ==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.2.1.tgz",
+      "integrity": "sha512-P5VWDj25r7kj7kl4pN2rG/RN2c1TLfYYYZYULnS/35nFDjBai+hBeo3MDrYZS7p6IoY3YHZnt2vq4L6mKnLk0g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.2",
+        "@jest/types": "^29.2.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -16658,9 +16651,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
+          "version": "29.2.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+          "integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
           "dev": true,
           "requires": {
             "@jest/schemas": "^29.0.0",
@@ -16761,12 +16754,13 @@
       }
     },
     "jest-worker": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.2.tgz",
-      "integrity": "sha512-EyvBlYcvd2pg28yg5A3OODQnqK9LI1kitnGUZUG5/NYIeaRgewtYBKB5wlr7oXj8zPCkzev7EmnTCsrXK7V+Xw==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.2.1.tgz",
+      "integrity": "sha512-ROHTZ+oj7sBrgtv46zZ84uWky71AoYi0vEV9CdEtc1FQunsoAGe5HbQmW76nI5QWdvECVPrSi1MCVUmizSavMg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
+        "jest-util": "^29.2.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -16781,6 +16775,12 @@
           }
         }
       }
+    },
+    "js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -17092,9 +17092,9 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
-      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -17447,9 +17447,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.0.2.tgz",
-      "integrity": "sha512-wp3CdtUa3cSJVFn3Miu5a1+pxc1iPIQTenOAn+x5erXeN1+ryTcLesV5pbK/rlW5EKwp27x38MoYfNGaNXDDhg==",
+      "version": "29.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.2.1.tgz",
+      "integrity": "sha512-Y41Sa4aLCtKAXvwuIpTvcFBkyeYp2gdFWzXGA+ZNES3VwURIB165XO/z7CjETwzCCS53MjW/rLMyyqEnTtaOfA==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^29.0.0",
@@ -18316,9 +18316,9 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "unbox-primitive": {
@@ -18575,20 +18575,20 @@
       "dev": true
     },
     "zx": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.8.tgz",
-      "integrity": "sha512-sNjfDHzskqrSkWNj0TVhaowVK5AbpvuyuO1RBU4+LrFcgYI5u9CtyWWgUBRtRZl3bgGEF31zByszoBmwS47d1w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.1.1.tgz",
+      "integrity": "sha512-5YlTO2AJ+Ku2YuZKSSSqnUKuagcM/f/j4LmHs15O84Ch80Z9gzR09ZK3gR7GV+rc8IFpz2H/XNFtFVmj31yrZA==",
       "requires": {
         "@types/fs-extra": "^9.0.13",
         "@types/minimist": "^1.2.2",
-        "@types/node": "^18.6.3",
+        "@types/node": "^18.7.20",
         "@types/ps-tree": "^1.1.2",
         "@types/which": "^2.0.1",
         "chalk": "^5.0.1",
         "fs-extra": "^10.1.0",
         "globby": "^13.1.2",
         "minimist": "^1.2.6",
-        "node-fetch": "3.2.8",
+        "node-fetch": "3.2.10",
         "ps-tree": "^1.2.0",
         "which": "^2.0.2",
         "yaml": "^2.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "prompts": "^2.4.2",
         "ramda": "^0.28.0",
         "readdirp": "^3.6.0",
+        "simple-git": "^3.14.1",
         "ts-pattern": "^4.0.5",
         "zx": "^7.0.8"
       },
@@ -2129,6 +2130,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3811,7 +3825,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -8445,8 +8458,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mylas": {
       "version": "2.1.11",
@@ -9506,6 +9518,20 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/simple-git": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.14.1.tgz",
+      "integrity": "sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -12277,6 +12303,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -13537,7 +13576,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -17034,8 +17072,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mylas": {
       "version": "2.1.11",
@@ -17765,6 +17802,16 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "simple-git": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.14.1.tgz",
+      "integrity": "sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==",
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -32,20 +32,20 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
-    "@jest/globals": "^29.0.2",
+    "@jest/globals": "^29.2.1",
     "@jest/types": "^28.1.3",
     "@types/boxen": "^3.0.1",
     "@types/eslint-config-prettier": "^6.11.0",
     "@types/is-glob": "^4.0.2",
     "@types/jest": "^28.1.8",
     "@types/micromatch": "^4.0.2",
-    "@types/node": "^18.7.16",
+    "@types/node": "^18.11.0",
     "@types/ora": "^3.2.0",
-    "@types/prompts": "^2.0.14",
-    "@types/ramda": "^0.28.15",
-    "@typescript-eslint/eslint-plugin": "^5.36.2",
-    "@typescript-eslint/parser": "^5.36.2",
-    "eslint": "^8.23.0",
+    "@types/prompts": "^2.4.1",
+    "@types/ramda": "^0.28.16",
+    "@typescript-eslint/eslint-plugin": "^5.40.1",
+    "@typescript-eslint/parser": "^5.40.1",
+    "eslint": "^8.25.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.5.1",
@@ -60,13 +60,13 @@
     "ts-jest": "^28.0.8",
     "ts-node": "^10.9.1",
     "tsc-alias": "^1.7.0",
-    "typescript": "^4.8.3"
+    "typescript": "^4.8.4"
   },
   "dependencies": {
     "boxen": "^7.0.0",
     "fast-glob": "^3.2.12",
-    "fp-ts": "^2.12.3",
-    "io-ts": "^2.2.18",
+    "fp-ts": "^2.13.1",
+    "io-ts": "^2.2.19",
     "is-glob": "^4.0.3",
     "micromatch": "^4.0.5",
     "monocle-ts": "^2.3.13",
@@ -76,6 +76,6 @@
     "readdirp": "^3.6.0",
     "simple-git": "^3.14.1",
     "ts-pattern": "^4.0.5",
-    "zx": "^7.0.8"
+    "zx": "^7.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "prompts": "^2.4.2",
     "ramda": "^0.28.0",
     "readdirp": "^3.6.0",
+    "simple-git": "^3.14.1",
     "ts-pattern": "^4.0.5",
     "zx": "^7.0.8"
   }

--- a/setup-test-data/setup-scripts/createConfigGroup.test.sh
+++ b/setup-test-data/setup-scripts/createConfigGroup.test.sh
@@ -2,9 +2,7 @@
 
 TARGET_DIR="$DATA_DIR/create-config-grp"
 
-echo "Creating test data directory for testing the createConfigGroup command..."
 mkdir -p "$TARGET_DIR/mock-dots"
-echo "Done!"
 
 echo "Populating mock-dots directory with some fake config groups..."
 MOCK_CONFIG_GRP_NAMES=("npm" "git" "bat" "cava")
@@ -12,4 +10,3 @@ MOCK_CONFIG_GRP_NAMES=("npm" "git" "bat" "cava")
 for CONFIG_GRP_NAME in "${MOCK_CONFIG_GRP_NAMES[@]}"; do
   mkdir -p "$TARGET_DIR/mock-dots/$CONFIG_GRP_NAME"
 done
-echo -e "Done!\n"

--- a/setup-test-data/setup-scripts/learning.test.sh
+++ b/setup-test-data/setup-scripts/learning.test.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 
-echo "Creating test data directory for learning tests..."
-
 echo "For fs-extra..."
 mkdir -p "$DATA_DIR/learning/fs-extra/sample"
-echo "Done!"
 
 echo "For readdirp..."
 mkdir -p "$DATA_DIR/learning/readdirp/dirOne"
@@ -24,7 +21,6 @@ touch $DATA_DIR/learning/readdirp/dirOne/innerFour/{destinations.json,farrow.cc}
 
 mkdir -p "$DATA_DIR/learning/readdirp/dirOne/inner/innerTwo"
 touch $DATA_DIR/learning/readdirp/dirOne/inner/innerTwo/{destinations.json,farrow.ts}
-echo "Done!"
 
 echo "For globby..."
 mkdir -p "$DATA_DIR/learning/globby"
@@ -35,4 +31,3 @@ touch $DATA_DIR/learning/globby/inner/{sample.ts,bat.txt,tmp.rs,orange.css}
 
 mkdir -p "$DATA_DIR/learning/globby/inner/inner"
 touch $DATA_DIR/learning/globby/inner/{stat.txt,service.html}
-echo -e "Done!\n"

--- a/setup-test-data/setup-scripts/link.test.sh
+++ b/setup-test-data/setup-scripts/link.test.sh
@@ -2,11 +2,11 @@
 
 TARGET_DIR="$DATA_DIR/link"
 
-echo "Creating test data directory for testing the link command..."
 mkdir -p "$TARGET_DIR/mock-dots"
 mkdir -p "$TARGET_DIR/valid-mock-dots"
 
-echo "Populating mock-dots directory with fake dots..."
+echo "Populating mock-dots directory with fake dot-files and mock config groups..."
+
 MOCK_CONFIG_GRP_PATHS=("$TARGET_DIR/mock-dots/npm" "$TARGET_DIR/valid-mock-dots/npm" "$TARGET_DIR/mock-dots/git" "$TARGET_DIR/valid-mock-dots/git" "$TARGET_DIR/mock-dots/bat" "$TARGET_DIR/valid-mock-dots/bat" "$TARGET_DIR/mock-dots/neovim" "$TARGET_DIR/valid-mock-dots/neovim" "$TARGET_DIR/mock-dots/withAllIgnored" "$TARGET_DIR/mock-dots/withSomeIgnored" "$TARGET_DIR/mock-dots/withPathIssues" "$TARGET_DIR/mock-dots/tilix" "$TARGET_DIR/valid-mock-dots/tilix")
 
 for CONFIG_GRP_PATH in "${MOCK_CONFIG_GRP_PATHS[@]}"; do
@@ -36,4 +36,3 @@ touch $TARGET_DIR/mock-dots/withSomeIgnored/{navi.config.yaml,navi.sample.json,n
 touch $TARGET_DIR/mock-dots/withPathIssues/{sample.rs,setup.ts,.configrc}
 
 mkdir -p "$TARGET_DIR/mock-home"
-echo -e "Done!\n"

--- a/setup-test-data/setup-scripts/sync.test.sh
+++ b/setup-test-data/setup-scripts/sync.test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+TARGET_DIR="$DATA_DIR/sync"
+
+echo "Creating test data directory for testing the sync command..."
+mkdir -p "$TARGET_DIR/valid-git-repo-working"
+mkdir -p "$TARGET_DIR/valid-git-repo-clean"
+
+echo "Setting up git in mock repos..."
+echo "Setting up working mock repo..."
+git -C "$TARGET_DIR/valid-git-repo-working" init
+touch $TARGET_DIR/valid-git-repo-working/{sample.txt,.gitignore,README.md,index.ts,utils.ts}
+git -C "$TARGET_DIR/valid-git-repo-working" add --all
+git -C "$TARGET_DIR/valid-git-repo-working" commit -m "init"
+
+echo -e "\nSetting up clean mock repo"
+git -C "$TARGET_DIR/valid-git-repo-clean" init
+touch $TARGET_DIR/valid-git-repo-clean/{sample.md,.gitignore,index.rs,utils.rs}
+git -C "$TARGET_DIR/valid-git-repo-clean" add --all
+git -C "$TARGET_DIR/valid-git-repo-clean" commit -m "init"

--- a/setup-test-data/setup-scripts/sync.test.sh
+++ b/setup-test-data/setup-scripts/sync.test.sh
@@ -7,9 +7,6 @@ mkdir -p "$TARGET_DIR/valid-git-repo-working"
 mkdir -p "$TARGET_DIR/valid-git-repo-clean"
 
 echo "Setting up git in mock repos..."
-git config user.name "GitHub Actions Bot"
-git config user.email "<>"
-
 echo "Setting up working mock repo..."
 git -C "$TARGET_DIR/valid-git-repo-working" init
 touch $TARGET_DIR/valid-git-repo-working/{sample.txt,.gitignore,README.md,index.ts,utils.ts}

--- a/setup-test-data/setup-scripts/sync.test.sh
+++ b/setup-test-data/setup-scripts/sync.test.sh
@@ -7,6 +7,9 @@ mkdir -p "$TARGET_DIR/valid-git-repo-working"
 mkdir -p "$TARGET_DIR/valid-git-repo-clean"
 
 echo "Setting up git in mock repos..."
+git config user.name "GitHub Actions Bot"
+git config user.email "<>"
+
 echo "Setting up working mock repo..."
 git -C "$TARGET_DIR/valid-git-repo-working" init
 touch $TARGET_DIR/valid-git-repo-working/{sample.txt,.gitignore,README.md,index.ts,utils.ts}

--- a/setup-test-data/setup-scripts/sync.test.sh
+++ b/setup-test-data/setup-scripts/sync.test.sh
@@ -2,19 +2,30 @@
 
 TARGET_DIR="$DATA_DIR/sync"
 
-echo "Creating test data directory for testing the sync command..."
 mkdir -p "$TARGET_DIR/valid-git-repo-working"
 mkdir -p "$TARGET_DIR/valid-git-repo-clean"
 
-echo "Setting up git in mock repos..."
-echo "Setting up working mock repo..."
+echo -e "Setting up mock repo with dirty working tree..."
 git -C "$TARGET_DIR/valid-git-repo-working" init
 touch $TARGET_DIR/valid-git-repo-working/{sample.txt,.gitignore,README.md,index.ts,utils.ts}
+
 git -C "$TARGET_DIR/valid-git-repo-working" add --all
 git -C "$TARGET_DIR/valid-git-repo-working" commit -m "init"
 
-echo -e "\nSetting up clean mock repo"
+git clone --bare "$TARGET_DIR/valid-git-repo-working" "$TARGET_DIR/valid-git-repo-working-upstream"
+
+git -C "$TARGET_DIR/valid-git-repo-working" remote add origin "$TARGET_DIR/valid-git-repo-working-upstream"
+git -C "$TARGET_DIR/valid-git-repo-working" push -u origin HEAD
+echo -e "Done!\n"
+
+echo -e "Setting up mock repo with clean working tree..."
 git -C "$TARGET_DIR/valid-git-repo-clean" init
 touch $TARGET_DIR/valid-git-repo-clean/{sample.md,.gitignore,index.rs,utils.rs}
+
 git -C "$TARGET_DIR/valid-git-repo-clean" add --all
 git -C "$TARGET_DIR/valid-git-repo-clean" commit -m "init"
+
+git clone --bare "$TARGET_DIR/valid-git-repo-clean" "$TARGET_DIR/valid-git-repo-clean-upstream"
+
+git -C "$TARGET_DIR/valid-git-repo-clean" remote add origin "$TARGET_DIR/valid-git-repo-clean-upstream"
+git -C "$TARGET_DIR/valid-git-repo-clean" push -u origin HEAD

--- a/setup-test-data/setup-scripts/unlink.test.sh
+++ b/setup-test-data/setup-scripts/unlink.test.sh
@@ -2,11 +2,11 @@
 
 TARGET_DIR="$DATA_DIR/unlink"
 
-echo "Creating test data directory for testing the unlink command..."
 mkdir -p "$TARGET_DIR/mock-dots"
 mkdir -p "$TARGET_DIR/valid-mock-dots"
 
-echo "Populating mock-dots directory with fake dots..."
+echo "Populating mock dotfiles directory with fake config groups..."
+
 MOCK_CONFIG_GRP_PATHS=("$TARGET_DIR/mock-dots/npm" "$TARGET_DIR/valid-mock-dots/npm" "$TARGET_DIR/mock-dots/git" "$TARGET_DIR/valid-mock-dots/git" "$TARGET_DIR/mock-dots/bat" "$TARGET_DIR/valid-mock-dots/bat" "$TARGET_DIR/mock-dots/neovim" "$TARGET_DIR/valid-mock-dots/neovim" "$TARGET_DIR/mock-dots/withAllIgnored" "$TARGET_DIR/mock-dots/withSomeIgnored" "$TARGET_DIR/mock-dots/withPathIssues" "$TARGET_DIR/mock-dots/withAllDotsToOneLoc" "$TARGET_DIR/mock-dots/tilix" "$TARGET_DIR/valid-mock-dots/tilix")
 
 for CONFIG_GRP_PATH in "${MOCK_CONFIG_GRP_PATHS[@]}"; do
@@ -37,4 +37,3 @@ touch $TARGET_DIR/mock-dots/withPathIssues/{sample.rs,setup.ts,.configrc}
 touch $TARGET_DIR/mock-dots/withAllDotsToOneLoc/{sample.rs,setup.ts,.configrc}
 
 mkdir -p "$TARGET_DIR/mock-home"
-echo -e "Done!\n"

--- a/setup-test-data/setup.sh
+++ b/setup-test-data/setup.sh
@@ -8,6 +8,7 @@ test -d "$DATA_DIR" && rm -rf "$DATA_DIR"
 echo "Seting up test-data directory...."
 mkdir "$DATA_DIR"
 
+source "$rootDir/setup-scripts/sync.test.sh"
 source "$rootDir/setup-scripts/link.test.sh"
 source "$rootDir/setup-scripts/unlink.test.sh"
 source "$rootDir/setup-scripts/learning.test.sh"

--- a/setup-test-data/setup.sh
+++ b/setup-test-data/setup.sh
@@ -5,11 +5,28 @@ DATA_DIR="$(dirname "$rootDir")/tests/test-data"
 
 test -d "$DATA_DIR" && rm -rf "$DATA_DIR"
 
-echo "Seting up test-data directory...."
+echo -e "Seting up mock data for tests...\n\n"
+
 mkdir "$DATA_DIR"
 
+echo -e "Setting up test-data for the sync command tests...\n"
 source "$rootDir/setup-scripts/sync.test.sh"
+echo -e "Done!\n\n"
+
+echo "Setting up test-data for the link command tests..."
 source "$rootDir/setup-scripts/link.test.sh"
+echo -e "Done!\n\n"
+
+echo "Setting up test-data for the unlink command tests..."
 source "$rootDir/setup-scripts/unlink.test.sh"
+echo -e "Done!\n\n"
+
+echo "Setting up test-data for the learning tests..."
 source "$rootDir/setup-scripts/learning.test.sh"
+echo -e "Done!\n\n"
+
+echo "Setting up test-data for the createConfigGroup command tests..."
 source "$rootDir/setup-scripts/createConfigGroup.test.sh"
+echo -e "Done!\n\n"
+
+echo "Setup Complete :)"

--- a/src/app/configGroup.ts
+++ b/src/app/configGroup.ts
@@ -22,7 +22,7 @@ import { expandShellVariablesInString } from '@lib/shellVarStrExpander';
 import { compose, lensProp, omit, pick, view } from 'ramda';
 import { readJson, doesPathExist, getOnlyValueFromEntriesArr } from '@utils/index';
 import {
-  getPathToDotfilesDir,
+  getPathToDotfilesDirPath,
   getAllOperableFilesFromConfigGroupDir,
 } from './helpers';
 import {
@@ -77,7 +77,7 @@ export function generateAbsolutePathToConfigGroupDir(
     O.fromPredicate(path.isAbsolute),
     O.match(
       flow(
-        getPathToDotfilesDir,
+        getPathToDotfilesDirPath,
         O.map(dotfilesDirPath => path.join(dotfilesDirPath, configGroupNameOrPath))
       ),
       O.some

--- a/src/app/helpers.ts
+++ b/src/app/helpers.ts
@@ -86,7 +86,7 @@ export const linkOperationTypeToPastTense: Record<LinkCmdOperationType, string> 
   symlink: 'symlinked',
 };
 
-export function getPathToDotfilesDir() {
+export function getPathToDotfilesDirPath() {
   return pipe(
     SHELL_VARS_TO_CONFIG_GRP_DIRS,
     RNEA.map(expandShellVariablesInString),
@@ -125,7 +125,7 @@ export function getAllConfigGroupDirPaths(): TE.TaskEither<Error, string[]> {
   return TE.tryCatch(async () => {
     const configGroupPaths = [] as string[];
 
-    const dotfilesDirPath = getPathToDotfilesDir();
+    const dotfilesDirPath = getPathToDotfilesDirPath();
     if (O.isNone(dotfilesDirPath)) {
       throw new Error('Could not find dotfiles directory');
     }
@@ -142,14 +142,14 @@ export function getAllConfigGroupDirPaths(): TE.TaskEither<Error, string[]> {
     }
 
     return configGroupPaths;
-  }, generateConfigGroupDirPathsRetrievalError());
+  }, getPathToDotfilesDirPathRetrievalError());
 }
 
-function generateConfigGroupDirPathsRetrievalError() {
+export function getPathToDotfilesDirPathRetrievalError() {
   return () =>
     new Error(
       chalk.bold.red(
-        'Could not find where you keep your configuration groups. Are you sure you have correctly set the required env variables? If so, then perhaps you have no configuration groups yet.'
+        `Could not find where you keep your configuration groups. Are you sure you have correctly set the required env variables (${SHELL_VARS_TO_CONFIG_GRP_DIRS})? If so, then perhaps you have no configuration groups yet.`
       )
     );
 }

--- a/src/cmds/createConfigGroup.ts
+++ b/src/cmds/createConfigGroup.ts
@@ -80,7 +80,7 @@ function generateConfigGroupDirForNonExistingOnes(absPath: string) {
     doesPathExist(absPath),
     TE.swap,
     TE.mapLeft(() => `${absPath} already exists. Skipping...`),
-    TE.chain(flow(() => absPath, createDirIfItDoesNotExist, TE.fromTask)),
+    TE.chainW(flow(() => absPath, createDirIfItDoesNotExist, TE.fromTask)),
     TE.chainFirstTaskK(() => createDefaultDestinationRecordFile(absPath)),
     TE.map(() => `${path.basename(absPath)} config group created (${absPath})`)
   ) as TE.TaskEither<string, string>;

--- a/src/cmds/link.ts
+++ b/src/cmds/link.ts
@@ -1,14 +1,21 @@
 import * as A from 'fp-ts/lib/Array';
+import * as L from 'monocle-ts/Lens';
+import * as O from 'fp-ts/lib/Option';
 import * as T from 'fp-ts/lib/Task';
 import * as TE from 'fp-ts/lib/TaskEither';
+import * as RC from 'fp-ts/lib/Record';
 
 import path from 'path';
-import parseCliArgs from '@lib/minimal-argp/index';
 
 import { pipe } from 'fp-ts/lib/function';
 import { match, P } from 'ts-pattern';
 import { ExitCodes } from '../constants';
 import { newAggregateError } from '@utils/AggregateError';
+import {
+  ParserOutput,
+  default as parseArgv,
+  optionConfigConstructor,
+} from '@lib/arg-parser';
 import {
   isNotIgnored,
   getFilesFromConfigGroup,
@@ -35,25 +42,20 @@ import {
   LinkCmdOperationType,
 } from '@types';
 
-const linkCmdCliOptionsConfig = {
-  options: {
-    hardlink: {
-      type: Boolean,
-      alias: 'H',
-    },
-    copy: {
-      type: Boolean,
-      alias: 'c',
-    },
-  },
-} as const;
+interface ParsedCmdOptions {
+  readonly hardlink: boolean;
+  readonly copy: boolean;
+  readonly yes: boolean;
+}
 
 export default async function main(
   passedArguments: string[],
   cliOptions: string[] = []
 ) {
+  const parsedCmdOptions: ParsedCmdOptions = parseCmdOptions(cliOptions);
+
   const configGroupNamesOrDirPaths = A.isEmpty(passedArguments)
-    ? await getPathsToAllConfigGroupDirsInExistence()
+    ? await getPathsToAllConfigGroupDirsInExistence(parsedCmdOptions.yes)
     : passedArguments;
 
   const cmdOutput = await match(configGroupNamesOrDirPaths)
@@ -61,20 +63,60 @@ export default async function main(
     .with({ _tag: 'Left' }, (_, { left }) =>
       exitCli(left.message, ExitCodes.GENERAL)
     )
-    .with({ _tag: 'Right' }, (_, { right }) => linkCmd(right, cliOptions))
-    .with(P.array(P.string), (_, value) => linkCmd(value, cliOptions))
+    .with({ _tag: 'Right' }, (_, { right }) => linkCmd(right, parsedCmdOptions))
+    .with(P.array(P.string), (_, value) => linkCmd(value, parsedCmdOptions))
     .exhaustive();
 
   return typeof cmdOutput === 'function' ? cmdOutput() : cmdOutput;
 }
 
+function parseCmdOptions(rawCmdOptions: string[]): ParsedCmdOptions {
+  const linkCmdOptionsConfig = generateOptionConfig();
+
+  const OptionsLens = pipe(
+    L.id<ParserOutput<typeof linkCmdOptionsConfig>>(),
+    L.prop('options')
+  );
+
+  return pipe(
+    rawCmdOptions,
+    parseArgv(linkCmdOptionsConfig),
+    OptionsLens.get,
+    RC.map(O.getOrElse(() => false))
+  );
+}
+
+function generateOptionConfig() {
+  return {
+    options: {
+      hardlink: optionConfigConstructor({
+        parser: () => true,
+        isFlag: true,
+        aliases: ['H'],
+      }),
+
+      copy: optionConfigConstructor({
+        parser: () => true,
+        isFlag: true,
+        aliases: ['c'],
+      }),
+
+      yes: optionConfigConstructor({
+        parser: () => true,
+        isFlag: true,
+        aliases: ['y'],
+      }),
+    },
+  };
+}
+
 async function linkCmd(
   configGroupNamesOrDirPaths: string[],
-  cliOptions: string[] = []
+  cliOptions: ParsedCmdOptions
 ): Promise<CmdResponse<ConfigGroup[]>> {
   const chosenLinkCmdOperationFn = pipe(
     cliOptions,
-    parseCmdOptions,
+    determineLinkCmdOperationToPerform,
     performChosenLinkCmdOperation
   );
 
@@ -94,21 +136,8 @@ async function linkCmd(
   };
 }
 
-function parseCmdOptions(rawCmdOptions: string[]) {
-  const { options: parsedLinkCmdOptions } = pipe(
-    rawCmdOptions,
-    parseCliArgs(linkCmdCliOptionsConfig)
-  );
-
-  return determineLinkCmdOperationToPerform(parsedLinkCmdOptions);
-}
-
-interface ParsedLinkCmdOptions {
-  readonly hardlink: boolean;
-  readonly copy: boolean;
-}
 function determineLinkCmdOperationToPerform(
-  parsedLinkCmdOptions: ParsedLinkCmdOptions
+  parsedLinkCmdOptions: ParsedCmdOptions
 ) {
   type ValidLinkCmdOptionConfiguration =
     | [true, false]

--- a/src/cmds/link.ts
+++ b/src/cmds/link.ts
@@ -56,7 +56,6 @@ export default async function main(
     ? await getPathsToAllConfigGroupDirsInExistence()
     : passedArguments;
 
-  // eslint-disable-next-line no-return-await
   const cmdOutput = await match(configGroupNamesOrDirPaths)
     .with(ExitCodes.OK as 0, exitCliWithCodeOnly)
     .with({ _tag: 'Left' }, (_, { left }) =>

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -168,10 +168,8 @@ function repoHasACleanWorkingTree(dirPath: string) {
       await execShellCmd(
         `[[ $(git -C ${dirPath} status --porcelain | wc -l) -gt "0" ]]`
       );
-      console.log({ dirPath });
       return SYNC_CMD_STATES.DOTFILES_DIR_HAS_CHANGES;
-    } catch (e) {
-      console.log({ e });
+    } catch {
       return SYNC_CMD_STATES.DOTFILES_DIR_HAS_NO_CHANGES;
     }
   };

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -151,7 +151,10 @@ function isGitRepo(dirPath: string) {
   return TE.tryCatch(
     async () => {
       // This shell command checks whether a specific directory is a git repo. Gotten from here: https://stackoverflow.com/a/39518382/17612886
-      await execShellCmd(`git -C ${dirPath} rev-parse 2>/dev/null`, 'forGitRepoCheck');
+      await execShellCmd(
+        `git -C ${dirPath} rev-parse 2>/dev/null`,
+        'forGitRepoCheck'
+      );
       return SYNC_CMD_STATES.DOTFILES_DIR_IS_VALID_GIT_REPO;
     },
     () => SYNC_CMD_STATES.DOTFILES_DIR_IS_NOT_GIT_REPO
@@ -162,9 +165,10 @@ function isGitRepo(dirPath: string) {
 function repoHasACleanWorkingTree(dirPath: string) {
   return async () => {
     try {
-      await execShellCmd(
+      const { stdout } = await execShellCmd(
         `[[ $(git -C ${dirPath} status --porcelain | wc -l) -gt "0" ]]`
       );
+      console.log({ stdout });
       return SYNC_CMD_STATES.DOTFILES_DIR_HAS_CHANGES;
     } catch {
       return SYNC_CMD_STATES.DOTFILES_DIR_HAS_NO_CHANGES;

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -165,12 +165,13 @@ function isGitRepo(dirPath: string) {
 function repoHasACleanWorkingTree(dirPath: string) {
   return async () => {
     try {
-      const { stdout } = await execShellCmd(
+      await execShellCmd(
         `[[ $(git -C ${dirPath} status --porcelain | wc -l) -gt "0" ]]`
       );
-      console.log({ stdout });
+      console.log({ dirPath });
       return SYNC_CMD_STATES.DOTFILES_DIR_HAS_CHANGES;
-    } catch {
+    } catch (e) {
+      console.log({ e });
       return SYNC_CMD_STATES.DOTFILES_DIR_HAS_NO_CHANGES;
     }
   };

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -1,0 +1,80 @@
+import * as E from 'fp-ts/Either';
+
+import { pipe } from 'fp-ts/lib/function';
+import { match } from 'ts-pattern';
+import { ExitCodes } from 'src/constants';
+import { CmdResponse } from '@types';
+import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
+import {
+  exitCli,
+  getPathToDotfilesDirPath,
+  getPathToDotfilesDirPathRetrievalError,
+} from '@app/helpers';
+import parseCliArgs from '@lib/minimal-argp';
+
+const syncCmdCliOptionsConfig = {
+  options: {
+    custom: {
+      type: Boolean,
+      alias: 'C',
+    },
+  },
+} as const;
+
+const main = _main();
+
+// ! Exported for testing purposes
+export function _main(simpleGitInstanceToUse?: SimpleGit) {
+  return async (_: string[], cliOptions: string[] = []) => {
+    const simpleGitInstance = pipe(
+      simpleGitInstanceToUse,
+      E.fromNullable(new Error('No simple git instance was passed!')),
+      E.alt(generateSimpleGitInstance)
+    );
+
+    const cmdOutput = await match(simpleGitInstance)
+      .with({ _tag: 'Left' }, (___, { left: err }) =>
+        exitCli(err.message, ExitCodes.GENERAL)
+      )
+      .with({ _tag: 'Right' }, (___, { right }) => syncCmd(right, cliOptions))
+      .exhaustive();
+
+    return typeof cmdOutput === 'function' ? cmdOutput() : cmdOutput;
+  };
+}
+
+type SyncCmdSimpleGitOptions = Pick<
+  Partial<SimpleGitOptions>,
+  'baseDir' | 'binary' | 'trimmed' | 'maxConcurrentProcesses'
+>;
+
+function generateSimpleGitInstance() {
+  return pipe(
+    getPathToDotfilesDirPath(),
+    E.fromOption(getPathToDotfilesDirPathRetrievalError()),
+    E.map(generateSimpleGitOptions),
+    E.map(simpleGit)
+  );
+}
+
+function generateSimpleGitOptions(baseDir: string): SyncCmdSimpleGitOptions {
+  return {
+    baseDir,
+    binary: 'git',
+    maxConcurrentProcesses: 6,
+    trimmed: false,
+  };
+}
+
+async function syncCmd(simpleGitInstance: SimpleGit, cliOptions: string[]) {
+  const commitMessage = generateGitCommitMessage(cliOptions);
+}
+
+function generateGitCommitMessage(cliOptions: string[]) {
+  const { options: parsedSyncCmdOptions } = pipe(
+    cliOptions,
+    parseCliArgs(syncCmdCliOptionsConfig)
+  );
+}
+
+export default main;

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -1,61 +1,78 @@
 import * as E from 'fp-ts/Either';
+import * as O from 'fp-ts/lib/Option';
+import * as L from 'monocle-ts/Lens';
+import * as RC from 'fp-ts/lib/Record';
+import * as RT from 'fp-ts/lib/ReaderTask';
+import * as TE from 'fp-ts/lib/TaskEither';
 
-import { pipe } from 'fp-ts/lib/function';
-import { match } from 'ts-pattern';
-import { ExitCodes } from 'src/constants';
+import { ExitCodes } from '../constants';
 import { CmdResponse } from '@types';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { flow, identity, pipe } from 'fp-ts/lib/function';
+import { optionConfigConstructor } from '@lib/arg-parser';
+import { doesPathExistSync, execShellCmd } from '../utils/index';
 import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
 import {
   exitCli,
+  getParsedOptions,
   getPathToDotfilesDirPath,
   getPathToDotfilesDirPathRetrievalError,
 } from '@app/helpers';
-import parseCliArgs from '@lib/minimal-argp';
 
-const syncCmdCliOptionsConfig = {
-  options: {
-    custom: {
-      type: Boolean,
-      alias: 'C',
-    },
-  },
-} as const;
+interface ParsedCmdOptions {
+  readonly message: string;
+}
 
-const main = _main();
+// EXPORTED FOR TESTING PURPOSES ONLY
+export interface GitInstance {
+  readonly dotfilesDirPath: string;
+  readonly git: SimpleGit;
+}
 
-// ! Exported for testing purposes
-export function _main(simpleGitInstanceToUse?: SimpleGit) {
-  return async (_: string[], cliOptions: string[] = []) => {
-    const simpleGitInstance = pipe(
-      simpleGitInstanceToUse,
-      E.fromNullable(new Error('No simple git instance was passed!')),
-      E.alt(generateSimpleGitInstance)
-    );
-
-    const cmdOutput = await match(simpleGitInstance)
-      .with({ _tag: 'Left' }, (___, { left: err }) =>
-        exitCli(err.message, ExitCodes.GENERAL)
+// EXPORTED FOR TESTING PURPOSES ONLY
+// Ideally, we should have the gitInstance come as the last parameter, but it's more general than the cmdOptions parameter
+export function _main(gitInstance: E.Either<Error, GitInstance>) {
+  return (_: string[], cmdOptions: string[] = []) =>
+    pipe(
+      gitInstance,
+      TE.fromEither,
+      TE.foldW(
+        errorObj => async () => exitCli(errorObj.message, ExitCodes.GENERAL),
+        ({ git, dotfilesDirPath }) =>
+          async () =>
+            // The reason we are invoking this here is because we do not want to have to differentiate between an asynchronous function (Task)
+            // and a synchronous function (IO) later in the pipeline
+            await syncCmd(git, cmdOptions)(dotfilesDirPath)()
       )
-      .with({ _tag: 'Right' }, (___, { right }) => syncCmd(right, cliOptions))
-      .exhaustive();
+    );
+}
 
-    return typeof cmdOutput === 'function' ? cmdOutput() : cmdOutput;
-  };
+// EXPORTED FOR TESTING PURPOSES ONLY
+export function generateGitInstance() {
+  return pipe(
+    getPathToDotfilesDirPath(),
+    E.fromOption(generateMissingDotfilesDirPathError),
+    E.chain(doesPathExistSync),
+    E.mapLeft(getPathToDotfilesDirPathRetrievalError()),
+    E.map(
+      (dotfilesDirPath): GitInstance => ({
+        dotfilesDirPath,
+        git: pipe(dotfilesDirPath, generateSimpleGitOptions, simpleGit),
+      })
+    )
+  );
+}
+
+function generateMissingDotfilesDirPathError() {
+  return new Error(
+    'No action was taken, but the path to your dotfiles directory could not be determined. Please specify at least one of the required environment variables then try again. If the issue persists then you can open an issue on Github'
+  );
 }
 
 type SyncCmdSimpleGitOptions = Pick<
   Partial<SimpleGitOptions>,
   'baseDir' | 'binary' | 'trimmed' | 'maxConcurrentProcesses'
 >;
-
-function generateSimpleGitInstance() {
-  return pipe(
-    getPathToDotfilesDirPath(),
-    E.fromOption(getPathToDotfilesDirPathRetrievalError()),
-    E.map(generateSimpleGitOptions),
-    E.map(simpleGit)
-  );
-}
 
 function generateSimpleGitOptions(baseDir: string): SyncCmdSimpleGitOptions {
   return {
@@ -66,15 +83,159 @@ function generateSimpleGitOptions(baseDir: string): SyncCmdSimpleGitOptions {
   };
 }
 
-async function syncCmd(simpleGitInstance: SimpleGit, cliOptions: string[]) {
-  const commitMessage = generateGitCommitMessage(cliOptions);
+// EXPORTED FOR TESTING PURPOSES ONLY
+export enum SYNC_CMD_STATES {
+  GIT_IS_INSTALLED = 'Git is installed',
+
+  DOTFILES_DIR_IS_VALID_GIT_REPO = 'Dotfiles dir is a valid git repo',
+
+  DOTFILES_DIR_HAS_NO_CHANGES = 'No action was taken because nothing changed in your dotfiles directory',
+
+  DOTFILES_DIR_HAS_CHANGES = 'Dotfiles directory contains changes to be synced',
+
+  DOTFILES_SYNCED = 'Syncing Complete! You can check out the commit in your remote repository',
+
+  FATAL_ERROR = 'No action was taken as a an error has occurred. Please check your inputs and try again. If the error persists then create an issue on GitHub',
+
+  GIT_IS_NOT_INSTALLED = 'Sync Error! No action was taken because git is not installed on your system. This command requires git to be installed. Please do so before running this command again. If git is already installed, please create an issue on Github',
+
+  DOTFILES_DIR_IS_NOT_GIT_REPO = "Sync error! No action was taken because your dotfiles directory is not a git repository or it didn't have a remote set yet. You will need to make it a git repository. If it's already a git repo with a valid remote, please create an issue on Github",
 }
 
-function generateGitCommitMessage(cliOptions: string[]) {
-  const { options: parsedSyncCmdOptions } = pipe(
-    cliOptions,
-    parseCliArgs(syncCmdCliOptionsConfig)
+function syncCmd(git: SimpleGit, cmdOptions: string[]) {
+  return (dotfilesDirPath: string) =>
+    flow(
+      isGitInstalled,
+      TE.chain(() => isGitRepo(dotfilesDirPath)),
+      TE.chainW(() => pipe(dotfilesDirPath, repoHasACleanWorkingTree, TE.fromTask)),
+
+      TE.fold(
+        syncErrorStateMsg => async () =>
+          constructSyncCmdErrorResponse(syncErrorStateMsg),
+
+        dotfilesRepoStatus => async () => {
+          switch (dotfilesRepoStatus) {
+            case SYNC_CMD_STATES.DOTFILES_DIR_HAS_NO_CHANGES:
+              return constructSyncCmdSuccessResponse(
+                SYNC_CMD_STATES.DOTFILES_DIR_HAS_NO_CHANGES
+              );
+
+            case SYNC_CMD_STATES.DOTFILES_DIR_HAS_CHANGES: {
+              const commitMsg = generateGitCommitMessage(cmdOptions);
+              // Since this is within a `fold` we can perform a side effect
+              return await pipe(
+                performGitSyncOps(git)(dotfilesDirPath), // Side effect
+                RT.map(constructSyncCmdSuccessResponse)
+              )(commitMsg)();
+            }
+
+            default:
+              return constructSyncCmdErrorResponse(SYNC_CMD_STATES.FATAL_ERROR);
+          }
+        }
+      )
+    )();
+}
+
+function isGitInstalled() {
+  return TE.tryCatch(
+    async () => {
+      await execShellCmd(`command -v git &>/dev/null`, 'forGitCheck');
+      return SYNC_CMD_STATES.GIT_IS_INSTALLED;
+    },
+    () => SYNC_CMD_STATES.GIT_IS_NOT_INSTALLED
   );
 }
+
+function isGitRepo(dirPath: string) {
+  return TE.tryCatch(
+    async () => {
+      // This shell command checks whether a specific directory is a git repo. Gotten from here: https://stackoverflow.com/a/39518382/17612886
+      await execShellCmd(`git -C ${dirPath} rev-parse 2>/dev/null`, 'forGitRepoCheck');
+      return SYNC_CMD_STATES.DOTFILES_DIR_IS_VALID_GIT_REPO;
+    },
+    () => SYNC_CMD_STATES.DOTFILES_DIR_IS_NOT_GIT_REPO
+  );
+}
+
+// A 'clean working directory' means that there are no changes to be staged, committed, or pushed
+function repoHasACleanWorkingTree(dirPath: string) {
+  return async () => {
+    try {
+      await execShellCmd(
+        `[[ $(git -C ${dirPath} status --porcelain | wc -l) -gt "0" ]]`
+      );
+      return SYNC_CMD_STATES.DOTFILES_DIR_HAS_CHANGES;
+    } catch {
+      return SYNC_CMD_STATES.DOTFILES_DIR_HAS_NO_CHANGES;
+    }
+  };
+}
+
+function constructSyncCmdErrorResponse(
+  syncCmdStateVal: string
+): CmdResponse<string> {
+  return {
+    warnings: [],
+    errors: [syncCmdStateVal],
+    output: [],
+    forTest: '',
+  };
+}
+
+function constructSyncCmdSuccessResponse(
+  syncCmdStateVal: string
+): CmdResponse<string> {
+  return {
+    warnings: [],
+    errors: [],
+    output: [syncCmdStateVal],
+    forTest: '',
+  };
+}
+
+function performGitSyncOps(git: SimpleGit) {
+  return (dotfilesDirPath: string): RT.ReaderTask<string, string> =>
+    (commitMsg: string) =>
+    async () => {
+      await git.add([dotfilesDirPath, '--all']).commit(commitMsg).push();
+      return commitMsg;
+    };
+}
+
+function generateGitCommitMessage(cmdOptions: string[]) {
+  const CommitMessageLens = pipe(L.id<ParsedCmdOptions>(), L.prop('message'));
+
+  return pipe(
+    cmdOptions,
+    pipe(generateOptionConfig(), getParsedOptions),
+    RC.map(O.getOrElse(generateDefaultCommitMessage)),
+    CommitMessageLens.get
+  );
+}
+
+function generateOptionConfig() {
+  return {
+    options: {
+      message: optionConfigConstructor({
+        parser: rawMessageParser,
+        aliases: ['m'],
+      }),
+    },
+  };
+}
+
+function rawMessageParser([message]: NonEmptyArray<string>): string {
+  if (message.length === 0) return generateDefaultCommitMessage();
+  return message;
+}
+
+// EXPORTED FOR TESTING PURPOSES ONLY
+export function generateDefaultCommitMessage() {
+  return 'chore: dotfiles update!';
+}
+
+const main =
+  process.env.NODE_ENV === 'test' ? identity : _main(generateGitInstance());
 
 export default main;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,10 @@ export const SHELL_VARS_TO_CONFIG_GRP_DIRS = ['$DOTFILES', '$DOTS'] as const;
 
 export const SHELL_VARS_TO_CONFIG_GRP_DIRS_STR = '$DOTFILES or $DOTS';
 
+export const SHELL_EXEC_MOCK_VAR_NAME = 'SHELL_MOCK_' as const;
+
+export const SHELL_EXEC_MOCK_ERROR_HOOK = '$$ERROR$$';
+
 // This isn't in the `utils` file to avoid a cyclic dependency error
 export function getAbsolutePathsForFile(fileUrl: string) {
   return pipe(fileUrl, fileURLToPath, (__filename: string) => ({

--- a/src/lib/arg-parser/index.ts
+++ b/src/lib/arg-parser/index.ts
@@ -1,0 +1,5 @@
+import optionParser from './src';
+
+const argParser = optionParser;
+
+export default argParser;

--- a/src/lib/arg-parser/index.ts
+++ b/src/lib/arg-parser/index.ts
@@ -1,5 +1,11 @@
 import optionParser from './src';
+import { createOptionConfig } from './src/utils';
+import { ParserOutput, ParserConfig } from '@lib/arg-parser/src/types';
 
-const argParser = optionParser;
+const parseArgv = optionParser;
+type AnyParserOutput = ParserOutput<ParserConfig>;
 
-export default argParser;
+export default parseArgv;
+export const optionConfigConstructor = createOptionConfig;
+
+export type { ParserOutput, ParserConfig, AnyParserOutput };

--- a/src/lib/arg-parser/src/constants.ts
+++ b/src/lib/arg-parser/src/constants.ts
@@ -1,0 +1,10 @@
+export const optionStrPredicate = {
+  isAlias: (s: string) => /^-([^\d-])$/.test(s),
+  isLong: (s: string) => /^--(\S)[^=]+$/.test(s),
+  isCombinedShort: (s: string) => /^-[^\d-]{2,}$/.test(s),
+
+  // Targets those options in the format '--long=value'
+  containsValue: (s: string) => /^(--\S+?)=(.*)/.test(s),
+};
+
+export const FLAG_PLACEHOLDER_VALUE = 'TRUE';

--- a/src/lib/arg-parser/src/index.ts
+++ b/src/lib/arg-parser/src/index.ts
@@ -1,0 +1,169 @@
+import * as A from 'fp-ts/lib/Array';
+import * as L from 'monocle-ts/Lens';
+import * as O from 'fp-ts/lib/Option';
+import * as RC from 'fp-ts/lib/Record';
+import * as MO from 'monocle-ts/Optional';
+import * as NEA from 'fp-ts/lib/NonEmptyArray';
+
+import parseCliArgs from './parser';
+
+import { last } from 'fp-ts/lib/Semigroup';
+import { flow, identity, pipe } from 'fp-ts/lib/function';
+import {
+  Argv,
+  OptionConfig,
+  ParserConfig,
+  ParserOutput,
+  ParserResponse,
+  ResolvedParserOutput,
+  DefaultOptionValueMap,
+  PARSER_OUTPUT_TOKEN_TYPE,
+} from './types';
+
+export default function optionParser<PC extends ParserConfig>(parserConfig: PC) {
+  return (argv: Argv) => {
+    const defaultOptionValueMap =
+      generateDefaultOptionValueMapValueMap(parserConfig);
+
+    const parsedCliArgEntries = Array.from(parseCliArgs(parserConfig, argv));
+
+    return pipe(
+      parsedCliArgEntries,
+      resolveParsedCliArgEntries,
+      parseEntriesInResolvedParserOutputObj(parserConfig),
+      mergeParserOutputWithDefaults(defaultOptionValueMap)
+    ) as ParserOutput<PC>;
+  };
+}
+
+function generateDefaultOptionValueMapValueMap<PC extends ParserConfig>({
+  options,
+}: PC) {
+  const defaultValueOptional: MO.Optional<unknown, unknown> = {
+    getOption: defaultVal => O.fromNullable(defaultVal),
+    set: _ => identity,
+  };
+
+  const defaultOptionValueLens = pipe(
+    L.id<OptionConfig<unknown>>(),
+    L.prop('default'),
+    L.composeOptional(defaultValueOptional)
+  );
+
+  return pipe(
+    options,
+    RC.map(flow(fillInDefaultValuesForFlags, defaultOptionValueLens.getOption))
+  ) as DefaultOptionValueMap<PC>;
+}
+
+function fillInDefaultValuesForFlags(optionConfig: OptionConfig<unknown>) {
+  return {
+    ...optionConfig,
+    // For flags we know the default can only ever be true or false.
+    // Thus we try to fill in a default value for as long as the option is specified to be a flag
+    // However we must take into consideration that the default value might have been set in the option configuration and we would not want to overwrite it
+    // Here we take advantage of the fact that !!undefined === false, so we get the following results
+    // If option is flag and option default value is not set (optionConfig.default === undefined), fill in a default value of false
+    // If option is flag and option default value is set (optionConfig.default === true or false), Use default value as is: !!true === true and !!false === false
+    // If option is not a flag, then leave things be
+    default: optionConfig.isFlag ? !!optionConfig.default : optionConfig.default,
+  };
+}
+
+function resolveParsedCliArgEntries(
+  parsedCliArgEntries: ParserResponse[]
+): ResolvedParserOutput<ParserConfig> {
+  const initialResolvedParserOutputObj: ResolvedParserOutput<ParserConfig> = {
+    _: [],
+    options: {},
+    positionalArgs: [],
+  };
+
+  return pipe(
+    parsedCliArgEntries,
+
+    A.reduce(
+      initialResolvedParserOutputObj,
+
+      (resolvedParserResponseObj, parserResponseEntry) => {
+        switch (parserResponseEntry.resultType) {
+          case PARSER_OUTPUT_TOKEN_TYPE.VALID_OPTION: {
+            const { optionName, optionValue: currentOptionValue } =
+              parserResponseEntry;
+
+            const previousOptionValue =
+              resolvedParserResponseObj.options[optionName] ?? O.none;
+
+            const MonoidOptionValue = O.getMonoid(NEA.getSemigroup<string>());
+
+            resolvedParserResponseObj.options[optionName] = MonoidOptionValue.concat(
+              previousOptionValue,
+              currentOptionValue
+            );
+
+            break;
+          }
+
+          case PARSER_OUTPUT_TOKEN_TYPE.POSITIONAL_ARG:
+            resolvedParserResponseObj.positionalArgs.push(
+              parserResponseEntry.argName
+            );
+            break;
+
+          case PARSER_OUTPUT_TOKEN_TYPE.UNKNOWN_OPTION:
+            resolvedParserResponseObj._.push(parserResponseEntry.optionName);
+            break;
+
+          default:
+            break;
+        }
+
+        return resolvedParserResponseObj;
+      }
+    )
+  );
+}
+
+function parseEntriesInResolvedParserOutputObj<PC extends ParserConfig>(
+  parserConfig: ParserConfig
+) {
+  return (resolvedParserOutputObj: ResolvedParserOutput<PC>): ParserOutput<PC> => {
+    const OptionsLens = pipe(L.id<ResolvedParserOutput<PC>>(), L.prop('options'));
+
+    const parsedOptions = pipe(
+      resolvedParserOutputObj,
+      OptionsLens.get,
+      RC.mapWithIndex((optionName, rawOptionValue) =>
+        pipe(
+          rawOptionValue,
+          O.map(optionValue => {
+            const { parser, isFlag } = parserConfig.options[optionName];
+            return isFlag ? true : parser(optionValue);
+          })
+        )
+      )
+    ) as ParserOutput<PC>['options'];
+
+    return { ...resolvedParserOutputObj, options: parsedOptions };
+  };
+}
+
+function mergeParserOutputWithDefaults(
+  defaultOptionValueMap: DefaultOptionValueMap<ParserConfig>
+) {
+  return (parserOutputObj: ParserOutput<ParserConfig>) => {
+    const MonoidDefaultValMerge = O.getMonoid<unknown>(last<unknown>());
+    const OptionsLens = pipe(L.id<ParserOutput<ParserConfig>>(), L.prop('options'));
+
+    return pipe(
+      OptionsLens,
+
+      L.modify(passedOptionsValueMap =>
+        RC.getMonoid(MonoidDefaultValMerge).concat(
+          defaultOptionValueMap,
+          passedOptionsValueMap
+        )
+      )
+    )(parserOutputObj);
+  };
+}

--- a/src/lib/arg-parser/src/parser.ts
+++ b/src/lib/arg-parser/src/parser.ts
@@ -1,0 +1,209 @@
+import * as A from 'fp-ts/lib/Array';
+import * as O from 'fp-ts/lib/Option';
+import * as S from 'fp-ts/lib/string';
+
+import { not } from 'fp-ts/lib/Predicate';
+import { pipe } from 'fp-ts/lib/function';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { FLAG_PLACEHOLDER_VALUE } from './constants';
+import { ParserConfig, Argv, PARSER_TOKEN_TYPE } from './types';
+import {
+  isOptionStr,
+  normalizeOptionStr,
+  tokenizeArgvElement,
+  withArgvIndexIncrement,
+  generateOptionNameAliasMap,
+  validOptionResponseConstructor,
+  unknownOptionResponseConstructor,
+  positionalArgsResponseConstructor,
+  removeArgvIndexIncrementProperty,
+} from './utils';
+
+export default function* parseCliArgs(parserConfig: ParserConfig, argv: Argv) {
+  const aliasParser = parseAliases(parserConfig);
+  const longOptionParser = parseLongOption(parserConfig);
+  const combinedAliasParser = parseCombinedAliases(parserConfig);
+  const optionStringWithValueParser = parseOptionStrWithValue(parserConfig);
+
+  for (let rawArgvStrIndex = 0; rawArgvStrIndex < argv.length; ) {
+    const rawArgvStr = argv[rawArgvStrIndex];
+    const optionToken = tokenizeArgvElement(rawArgvStr);
+    const restOfArgvArr = argv.slice(rawArgvStrIndex + 1);
+
+    switch (optionToken) {
+      case PARSER_TOKEN_TYPE.LONG_OPT_STR: {
+        const { indexIncrement, ...parserResponse } = longOptionParser(
+          rawArgvStr,
+          restOfArgvArr
+        );
+
+        rawArgvStrIndex += indexIncrement;
+        yield parserResponse;
+
+        break;
+      }
+
+      case PARSER_TOKEN_TYPE.ALIAS_OPT_STR: {
+        const { indexIncrement, ...parserResponse } = aliasParser(
+          rawArgvStr,
+          restOfArgvArr
+        );
+
+        rawArgvStrIndex += indexIncrement;
+        yield parserResponse;
+
+        break;
+      }
+
+      case PARSER_TOKEN_TYPE.COMBINED_SHORT_OPT_STR: {
+        const combinedAliasParserResponse = combinedAliasParser(
+          rawArgvStr,
+          restOfArgvArr
+        );
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const aliasParserResponse of combinedAliasParserResponse) {
+          const parserResponse =
+            removeArgvIndexIncrementProperty(aliasParserResponse);
+
+          yield parserResponse;
+        }
+
+        // The reason we increment directly by one is because the convention with combined aliases is that each alias maps to an option that is a flag
+        // 'flag' here means that the option's value is a boolean, when the option is present the value is true and when it isn't it is false.
+        // Thus combined aliases do not have values to be skipped over as other kinds of options do, so we simply need to move to the next rawArgString the argv array
+        // to continue parsing. As an example: ['--long', 'value' '-abc', '-another-long' 'another-value']
+        // The combined aliases '-abc' will always have no values associated with it, so we move to the next option to be parsed which is a +1 from the index of the
+        // combined aliases string
+        rawArgvStrIndex += 1;
+        break;
+      }
+
+      case PARSER_TOKEN_TYPE.OPT_STR_WITH_VALUE: {
+        const parserResponse = optionStringWithValueParser(rawArgvStr);
+
+        // Same as above, this category of options are usually self-contained: they house both the option name and its value.
+        // Thus, the next option string to parse is simply an index away. No need to take into account other values
+
+        rawArgvStrIndex += 1;
+
+        yield parserResponse;
+        break;
+      }
+
+      case PARSER_TOKEN_TYPE.POSITIONAL_ARG: {
+        const parserResponse = positionalArgsResponseConstructor(rawArgvStr);
+
+        // Positional args have no value associated with them. So, after parsing, we move to the next option string to be parsed which will always be an
+        // index away
+        rawArgvStrIndex += 1;
+
+        yield parserResponse;
+        break;
+      }
+
+      default: {
+        const parserResponse = unknownOptionResponseConstructor(rawArgvStr);
+
+        // Represents the skipping of argv elements that do match any of the above criteria
+        rawArgvStrIndex += 1;
+
+        yield parserResponse;
+        break;
+      }
+    }
+  }
+}
+
+function parseLongOption({ options: optionConfigs }: ParserConfig) {
+  return (longOptionStr: string, restOfArgvArr: string[]) => {
+    const optionNameWithoutDashPrefix = normalizeOptionStr(longOptionStr);
+    const rawOptionValue = pipe(restOfArgvArr, A.takeLeftWhile(not(isOptionStr)));
+
+    const longOptionStrConfig = O.fromNullable(
+      optionConfigs[optionNameWithoutDashPrefix]
+    );
+
+    return pipe(
+      longOptionStrConfig,
+
+      O.foldW(
+        () =>
+          withArgvIndexIncrement(unknownOptionResponseConstructor)(longOptionStr)(
+            rawOptionValue.length
+          ),
+
+        optionConfig => {
+          const { isFlag } = optionConfig;
+
+          // prettier-ignore
+          // eslint-disable-next-line no-nested-ternary
+          const optionValue = A.isEmpty(rawOptionValue)
+            ? (isFlag ? [FLAG_PLACEHOLDER_VALUE] : null)
+            : rawOptionValue;
+
+          return withArgvIndexIncrement(validOptionResponseConstructor)(
+            optionNameWithoutDashPrefix,
+            optionValue as NonEmptyArray<string> | null
+          )(rawOptionValue.length);
+        }
+      )
+    );
+  };
+}
+
+function parseAliases(parserConfig: ParserConfig) {
+  const aliasMap = generateOptionNameAliasMap(parserConfig);
+
+  return (aliasOptionStr: string, restOfArgvArr: string[]) => {
+    const aliasWithoutDashPrefix = normalizeOptionStr(aliasOptionStr);
+    let correspondingAliasLongName = aliasMap[aliasWithoutDashPrefix];
+
+    if (!correspondingAliasLongName) {
+      // Here we are treating those unspecified (not present in configuration) aliases as long options so we can classify them as unknown later on
+      // and file them away properly
+      correspondingAliasLongName = aliasOptionStr;
+    }
+
+    return parseLongOption(parserConfig)(correspondingAliasLongName, restOfArgvArr);
+  };
+}
+
+function parseCombinedAliases(parserConfig: ParserConfig) {
+  const aliasParser = parseAliases(parserConfig);
+
+  return (combinedAliasStr: string, restOfArgvArr: string[]) => {
+    const aliasesArr = normalizeOptionStr(combinedAliasStr).split('');
+
+    return pipe(
+      aliasesArr,
+      A.map(aliasStr => aliasParser(aliasStr, restOfArgvArr))
+    );
+  };
+}
+
+function parseOptionStrWithValue({ options: optionsConfig }: ParserConfig) {
+  return (optionStrWithValue: string) => {
+    const [optionNameWithoutDashPrefix, optionValue] =
+      normalizeOptionStr(optionStrWithValue).split('=');
+
+    return pipe(
+      O.fromNullable(optionsConfig[optionNameWithoutDashPrefix]),
+
+      O.foldW(
+        unknownOptionResponseConstructor.bind(null, optionStrWithValue),
+
+        () => {
+          const parsedOptionValue = S.isEmpty(optionValue)
+            ? null
+            : ([optionValue] as NonEmptyArray<string>);
+
+          return validOptionResponseConstructor(
+            optionNameWithoutDashPrefix,
+            parsedOptionValue
+          );
+        }
+      )
+    );
+  };
+}

--- a/src/lib/arg-parser/src/types.ts
+++ b/src/lib/arg-parser/src/types.ts
@@ -1,0 +1,84 @@
+import { Option } from 'fp-ts/lib/Option';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+
+export type Argv = string[];
+
+export interface OptionConfig<OptionType> {
+  parser: (optionValue: NonEmptyArray<string>) => OptionType;
+  default?: OptionType;
+  aliases?: string[];
+  isFlag?: boolean;
+}
+
+export interface ParserConfig {
+  options: {
+    [OptionName: string]: OptionConfig<unknown>;
+  };
+}
+
+export interface ParserOutput<PC extends ParserConfig> {
+  _: string[];
+  positionalArgs: string[];
+  options: {
+    [OptionName in keyof PC['options']]: Option<
+      ReturnType<PC['options'][OptionName]['parser']>
+    >;
+  };
+}
+
+export type DefaultOptionValueMap<PC extends ParserConfig> = {
+  [OptionName in keyof PC['options']]: Option<PC['options'][OptionName]['default']>;
+};
+
+export type ResolvedParserOutput<PC extends ParserConfig> = {
+  _: string[];
+  positionalArgs: string[];
+  options: {
+    [OptionName in keyof PC['options']]: Option<NonEmptyArray<string>>;
+  };
+};
+
+export type AliasMap = {
+  [Alias: string]: string;
+};
+
+export enum PARSER_OUTPUT_TOKEN_TYPE {
+  UNKNOWN_OPTION = 'UNKNOWN_OPTION',
+  POSITIONAL_ARG = 'POSITIONAL_ARG',
+  VALID_OPTION = 'VALID_OPTION',
+}
+
+export interface UnknownOption {
+  resultType: PARSER_OUTPUT_TOKEN_TYPE.UNKNOWN_OPTION;
+  optionName: string;
+}
+
+export interface ValidOption {
+  resultType: PARSER_OUTPUT_TOKEN_TYPE.VALID_OPTION;
+  optionName: string;
+  optionValue: Option<NonEmptyArray<string>>;
+}
+
+export interface PositionalArg {
+  resultType: PARSER_OUTPUT_TOKEN_TYPE.POSITIONAL_ARG;
+  argName: string;
+}
+
+export type ParserResponse = UnknownOption | ValidOption | PositionalArg;
+
+export enum PARSER_TOKEN_TYPE {
+  // Example: ['--long', 'value']
+  LONG_OPT_STR = 'LONG_OPT_STR',
+
+  // Example: ['-l', '2']
+  ALIAS_OPT_STR = 'ALIAS_OPT_STR',
+
+  // Example: ['arg1', 'arg2', 'arg3']
+  POSITIONAL_ARG = 'POSITIONAL_ARG_TOKEN',
+
+  // Example: ['--amount=5']
+  OPT_STR_WITH_VALUE = 'OPT_STR_WITH_VALUE',
+
+  // Example: ['-abc']. Where a, b, and c are aliases for flags
+  COMBINED_SHORT_OPT_STR = 'COMBINED_SHORT_OPT_STR',
+}

--- a/src/lib/arg-parser/src/utils.ts
+++ b/src/lib/arg-parser/src/utils.ts
@@ -1,0 +1,134 @@
+import * as A from 'fp-ts/lib/Array';
+import * as O from 'fp-ts/lib/Option';
+import * as R from 'fp-ts/lib/Reader';
+import * as S from 'fp-ts/lib/string';
+import * as Rc from 'fp-ts/lib/Record';
+
+import { pipe } from 'fp-ts/lib/function';
+import { omit } from 'ramda';
+import { match } from 'ts-pattern';
+import { MonoidAny } from 'fp-ts/lib/boolean';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { optionStrPredicate } from './constants';
+import {
+  AliasMap,
+  ValidOption,
+  OptionConfig,
+  ParserConfig,
+  PositionalArg,
+  UnknownOption,
+  ParserResponse,
+  PARSER_TOKEN_TYPE,
+  PARSER_OUTPUT_TOKEN_TYPE,
+} from './types';
+
+// ! To mitigate some limitations with generic interfaces where type parameters cannot be inferred through usage and require a constructor of sorts to verify type information
+export function createOptionConfig<OptionType>(
+  rawOptionConfig: OptionConfig<OptionType>
+): OptionConfig<OptionType> {
+  return rawOptionConfig;
+}
+
+export function generateOptionNameAliasMap({ options }: ParserConfig): AliasMap {
+  const createAliasMapEntries = (optionName: string) =>
+    A.map<string, [string, string]>(alias => [alias, optionName]);
+
+  return pipe(
+    options,
+    Rc.toEntries,
+    A.chain(([optionName, { aliases = [] }]) =>
+      createAliasMapEntries(optionName)(aliases)
+    ),
+    Rc.fromEntries
+  );
+}
+
+export function normalizeOptionStr(optionStr: string): string {
+  const OPTION_STRING_PREFIX_REGEX = /^--|^-/;
+  return optionStr.replace(OPTION_STRING_PREFIX_REGEX, '');
+}
+
+export function isOptionStr(potentialOptionStr: string): boolean {
+  return pipe(
+    optionStrPredicate,
+    Rc.reduce(S.Ord)(MonoidAny.empty, (isOptionStrBool, optionStrPredicateFn) =>
+      MonoidAny.concat(isOptionStrBool, optionStrPredicateFn(potentialOptionStr))
+    )
+  );
+}
+
+export function tokenizeArgvElement(argvElem: string): PARSER_TOKEN_TYPE {
+  return match(argvElem)
+    .when(optionStrPredicate.isLong, () => PARSER_TOKEN_TYPE.LONG_OPT_STR)
+    .when(optionStrPredicate.isAlias, () => PARSER_TOKEN_TYPE.ALIAS_OPT_STR)
+    .when(
+      optionStrPredicate.isCombinedShort,
+      () => PARSER_TOKEN_TYPE.COMBINED_SHORT_OPT_STR
+    )
+    .when(
+      optionStrPredicate.containsValue,
+      () => PARSER_TOKEN_TYPE.OPT_STR_WITH_VALUE
+    )
+    .otherwise(() => PARSER_TOKEN_TYPE.POSITIONAL_ARG);
+}
+
+export function unknownOptionResponseConstructor(optionName: string): UnknownOption {
+  return {
+    resultType: PARSER_OUTPUT_TOKEN_TYPE.UNKNOWN_OPTION,
+    optionName,
+  };
+}
+
+export function validOptionResponseConstructor(
+  optionName: string,
+  optionValue: NonEmptyArray<string> | null | undefined
+): ValidOption {
+  return {
+    resultType: PARSER_OUTPUT_TOKEN_TYPE.VALID_OPTION,
+    optionName,
+    optionValue: O.fromNullable(optionValue),
+  };
+}
+
+export function positionalArgsResponseConstructor(argName: string): PositionalArg {
+  return {
+    resultType: PARSER_OUTPUT_TOKEN_TYPE.POSITIONAL_ARG,
+    argName,
+  };
+}
+
+type WithArgvIndexIncrement<PR extends ParserResponse> = PR & {
+  indexIncrement: number;
+};
+
+export function withArgvIndexIncrement<
+  ParserResponseConstructor extends (...args: any[]) => ParserResponse
+>(parserResponseConstructor: ParserResponseConstructor) {
+  return (
+      ...parserResponseConstructorArgs: Parameters<ParserResponseConstructor>
+    ): R.Reader<number, WithArgvIndexIncrement<ParserResponse>> =>
+    (indexIncrementCount: number) => {
+      const parserResponse = parserResponseConstructor(
+        ...parserResponseConstructorArgs
+      );
+
+      return { ...parserResponse, indexIncrement: indexIncrementCount + 1 };
+    };
+}
+
+export function removeArgvIndexIncrementProperty<PR extends ParserResponse>(
+  parserResponseWithArgvIncrementProp: WithArgvIndexIncrement<PR>
+) {
+  return omit(['indexIncrement'])(
+    parserResponseWithArgvIncrementProp
+  ) as unknown as PR;
+}
+
+// NOTE: For debugging purposes only
+export function trace<T>(...logContents: string[]) {
+  return (val: T) => {
+    const otherLogContents = A.isEmpty(logContents) ? ['Output: '] : logContents;
+    console.log(...otherLogContents, val);
+    return val;
+  };
+}

--- a/src/lib/arg-parser/test.ts
+++ b/src/lib/arg-parser/test.ts
@@ -1,0 +1,321 @@
+/* globals test, expect */
+import * as A from 'fp-ts/lib/Array';
+import * as O from 'fp-ts/lib/Option';
+import * as R from 'fp-ts/lib/Record';
+
+import optionParser from './src/index';
+
+import { identity, pipe } from 'fp-ts/lib/function';
+import { createOptionConfig, trace } from './src/utils';
+
+test('Should ensure that CLI argument parser works as intended ', () => {
+  // Arrange
+  const expectedPositionalArgs = ['tt', 'ferfer', 'fe', 'erge', 'ferfer'];
+
+  const expectedOptions = {
+    long: 'aaa',
+    many: 16,
+    ama: true,
+    bar: true,
+    cat: false,
+  };
+
+  const expectedUnknownOptions = ['--vaer', '--ragnarok', '-o'];
+
+  const sampleArgv = [
+    ...expectedPositionalArgs,
+    '--many=8',
+    '-ab',
+    ...expectedUnknownOptions,
+  ];
+
+  const parserConfig = {
+    options: {
+      long: createOptionConfig({
+        parser: ([optionValue]) => String(optionValue),
+        default: 'aaa',
+        aliases: ['l'],
+      }),
+
+      many: createOptionConfig({
+        parser: ([optionValue]) => Number(optionValue) * 2,
+      }),
+
+      ama: createOptionConfig({
+        parser: _ => true,
+        isFlag: true,
+        aliases: ['a'],
+      }),
+
+      bar: createOptionConfig({
+        parser: _ => true,
+        isFlag: true,
+        aliases: ['b'],
+      }),
+
+      cat: createOptionConfig({
+        parser: _ => true,
+        isFlag: true,
+        aliases: ['c'],
+      }),
+    },
+  };
+
+  // Act
+  const parserOutput = optionParser(parserConfig)(sampleArgv);
+
+  const { options, positionalArgs, _: unknownOptions } = parserOutput;
+
+  // Assert
+  expect(options).toMatchObject(pipe(expectedOptions, R.map(O.some)));
+  expect(positionalArgs).toIncludeSameMembers(expectedPositionalArgs);
+  expect(unknownOptions).toIncludeSameMembers(expectedUnknownOptions);
+});
+
+test('Should ensure parser can handle options that are not present in argv but have been specified in config without a default value', () => {
+  // Arrange
+  const expectedPositionalArgs = ['tt', 'ferfer', 'fe', 'erge', 'ferfer'];
+
+  const expectedOptions = {
+    long: O.none,
+    miles: O.some(10),
+    numOfPeople: O.some('5 people'),
+  };
+
+  const expectedUnknownOptions = ['--vaer', '--ragnarok', '-o'];
+
+  const sampleArgv = [
+    ...expectedPositionalArgs,
+    '-m',
+    '10',
+    '-n',
+    '5',
+    ...expectedUnknownOptions,
+  ];
+
+  const parserConfig = {
+    options: {
+      long: createOptionConfig({
+        parser: ([optionValue]) => String(optionValue),
+      }),
+
+      miles: createOptionConfig({
+        parser: ([optionValue]) => Number(optionValue),
+        aliases: ['m'],
+      }),
+
+      numOfPeople: createOptionConfig({
+        parser: ([optionValue]) => `${optionValue} people`,
+        aliases: ['n'],
+      }),
+    },
+  };
+
+  // Act
+  const parserOutput = optionParser(parserConfig)(sampleArgv);
+
+  const { options, positionalArgs, _: unknownOptions } = parserOutput;
+
+  // Assert
+  expect(options).toMatchObject(expectedOptions);
+  expect(positionalArgs).toIncludeSameMembers(expectedPositionalArgs);
+  expect(unknownOptions).toIncludeSameMembers(expectedUnknownOptions);
+});
+
+test('Should ensure parser has predictable behavior when it stumbles across an option with multiple values', () => {
+  // Arrange
+  const expectedPositionalArgs = ['tt', 'ferfer', 'fe', 'erge', 'ferfer'];
+  const multiValueOptionValsArr = ['John', 'Stacy', 'Mack', 'Arik', 'Halima', 'Nir'];
+
+  const expectedOptions = {
+    namesOfPeople: O.some(multiValueOptionValsArr),
+  };
+
+  const expectedUnknownOptions = ['--vaer', '--ragnarok', '-o'];
+
+  const sampleArgv = [
+    ...expectedPositionalArgs,
+    '-n',
+    ...multiValueOptionValsArr,
+    ...expectedUnknownOptions,
+  ];
+
+  const parserConfig = {
+    options: {
+      namesOfPeople: createOptionConfig({
+        parser: identity,
+        aliases: ['n'],
+      }),
+    },
+  };
+
+  // Act
+  const parserOutput = optionParser(parserConfig)(sampleArgv);
+
+  const { options, positionalArgs, _: unknownOptions } = parserOutput;
+
+  // Assert
+  expect(options).toMatchObject(expectedOptions);
+  expect(positionalArgs).toIncludeSameMembers(expectedPositionalArgs);
+  expect(unknownOptions).toIncludeSameMembers(expectedUnknownOptions);
+});
+
+test('Should ensure options passed multiple times with different sets of values are merged into a single array of values', () => {
+  // Arrange
+  const expectedPositionalArgs = ['tt', 'ferfer', 'fe', 'erge', 'ferfer'];
+
+  const optionValues = [
+    ['John', 'Stacy', 'Mack', 'Arik', 'Halima', 'Nir'],
+    ['Abby', 'Gale'],
+  ];
+
+  const expectedOptions = {
+    namesOfPeople: O.some(optionValues[0]),
+    other: O.some(optionValues[1]),
+  };
+
+  const expectedUnknownOptions = ['--vaer', '--ragnarok', '-g'];
+
+  const randomSplit = (arr: string[]) =>
+    pipe(Math.floor(Math.random() * A.size(arr)), trace('randomSplit: '));
+
+  const [firstOptionValsFirstSplit, firstOptionValsSecondSplit] = pipe(
+    optionValues[0],
+    A.splitAt(randomSplit(optionValues[0]))
+  );
+
+  const [secondOptionValFirstSplit, secondOptionValSecondSplit] = pipe(
+    optionValues[1],
+    A.splitAt(randomSplit(optionValues[1]))
+  );
+
+  const sampleArgv = [
+    ...expectedPositionalArgs,
+
+    '-n',
+    ...firstOptionValsFirstSplit,
+    '-n',
+    ...firstOptionValsSecondSplit,
+
+    '-o',
+    ...secondOptionValFirstSplit,
+    '-o',
+    ...secondOptionValSecondSplit,
+
+    ...expectedUnknownOptions,
+  ];
+
+  const parserConfig = {
+    options: {
+      namesOfPeople: createOptionConfig({
+        parser: identity,
+        aliases: ['n'],
+      }),
+
+      other: createOptionConfig({
+        parser: identity,
+        aliases: ['o'],
+      }),
+    },
+  };
+
+  // Act
+  const parserOutput = optionParser(parserConfig)(sampleArgv);
+
+  const { options, positionalArgs, _: unknownOptions } = parserOutput;
+
+  // Assert
+  expect(options).toMatchObject(expectedOptions);
+  expect(positionalArgs).toIncludeSameMembers(expectedPositionalArgs);
+  expect(unknownOptions).toIncludeSameMembers(expectedUnknownOptions);
+});
+
+test('Should check that parser can handle edge case where non of the specified options are present in the argv array', () => {
+  // Arrange
+  const expectedPositionalArgs = ['tt', 'ferfer', 'fe', 'erge', 'ferfer'];
+
+  const expectedOptions = {
+    namesOfPeople: O.none,
+    ama: O.none,
+    ttt: O.none,
+    razzy: O.none,
+  };
+
+  const expectedUnknownOptions = ['--vaer', '--ragnarok', '-o'];
+
+  const sampleArgv = [...expectedPositionalArgs, ...expectedUnknownOptions];
+
+  const parserConfig = {
+    options: {
+      namesOfPeople: createOptionConfig({
+        parser: identity,
+      }),
+
+      ama: createOptionConfig({
+        parser: identity,
+      }),
+
+      ttt: createOptionConfig({
+        parser: identity,
+      }),
+
+      razzy: createOptionConfig({
+        parser: identity,
+      }),
+    },
+  };
+
+  // Act
+  const parserOutput = optionParser(parserConfig)(sampleArgv);
+
+  const { options, positionalArgs, _: unknownOptions } = parserOutput;
+
+  // Assert
+  expect(options).toMatchObject(expectedOptions);
+  expect(positionalArgs).toIncludeSameMembers(expectedPositionalArgs);
+  expect(unknownOptions).toIncludeSameMembers(expectedUnknownOptions);
+});
+
+test('Parser should declare all options as un-found (excluding flags, those should be false) if argv array is empty', () => {
+  // Arrange
+
+  const expectedOptions = {
+    namesOfPeople: O.none,
+    ama: O.none,
+    ttt: O.none,
+    razzy: O.some(false),
+  };
+
+  const sampleArgv = [] as string[];
+
+  const parserConfig = {
+    options: {
+      namesOfPeople: createOptionConfig({
+        parser: identity,
+      }),
+
+      ama: createOptionConfig({
+        parser: identity,
+      }),
+
+      ttt: createOptionConfig({
+        parser: identity,
+      }),
+
+      razzy: createOptionConfig({
+        parser: identity,
+        isFlag: true,
+      }),
+    },
+  };
+
+  // Act
+  const parserOutput = optionParser(parserConfig)(sampleArgv);
+
+  const { options, positionalArgs, _: unknownOptions } = parserOutput;
+
+  // Assert
+  expect(options).toMatchObject(expectedOptions);
+  expect(positionalArgs).toBeEmpty();
+  expect(unknownOptions).toBeEmpty();
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,13 +70,13 @@ export type isOptional<Structure, MemberUnion extends keyof Structure> = Omit<
 
 export interface CmdResponse<T> {
   errors: AggregateError[] | string[];
-  warnings?: string[];
+  warnings: string[];
   output: string[];
   forTest: T; // NOTE: This return is for testing purposes only
 }
 
 export interface Cmd<RT> {
-  (args: string[], cliOptions: string[]): Promise<CmdResponse<RT>>;
+  (args: string[], cmdOptions: string[]): Promise<CmdResponse<RT>>;
 }
 
 export type SourcePath = Brand<string, 'Source Path'>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -162,7 +162,7 @@ export function createDirIfItDoesNotExist(dirPath: string): T.Task<void> {
 }
 
 export function execShellCmd(shellCmd: string, scope: string = '') {
-  const promisifiedExec = promisify(exec)(shellCmd);
+  const promisifiedExec = promisify(exec)(shellCmd, { shell: '/bin/bash' });
 
   return pipe(
     getEnv(`${SHELL_EXEC_MOCK_VAR_NAME}${scope}`),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -166,6 +166,7 @@ export function execShellCmd(shellCmd: string, scope: string = '') {
 
   return pipe(
     getEnv(`${SHELL_EXEC_MOCK_VAR_NAME}${scope}`),
+
     O.fold(
       () => promisifiedExec,
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,16 +1,23 @@
 import * as A from 'fp-ts/lib/Array';
-import * as IO from 'fp-ts/lib/IO';
+import * as E from 'fp-ts/lib/Either';
+import * as O from 'fp-ts/lib/Option';
 import * as S from 'fp-ts/lib/string';
 import * as T from 'fp-ts/lib/Task';
+import * as IO from 'fp-ts/lib/IO';
 import * as TE from 'fp-ts/lib/TaskEither';
 
 import boxen from 'boxen';
 
 import { pipe } from 'fp-ts/lib/function';
+import { exec } from 'child_process';
+import { getEnv } from '@lib/shellVarStrExpander';
+import { match, P } from 'ts-pattern';
+import { promisify } from 'util';
 import { isEmpty, slice } from 'ramda';
 import { chalk, fs as fsExtra } from 'zx';
 import { DestinationPath, SourcePath } from '@types';
 import { copyFile, link, symlink, unlink } from 'fs/promises';
+import { SHELL_EXEC_MOCK_ERROR_HOOK, SHELL_EXEC_MOCK_VAR_NAME } from '../constants';
 import {
   AggregateError,
   newAggregateError,
@@ -41,6 +48,18 @@ export function doesPathExist(
       throw new Error(`Could not find path to ${pathToEntity}`);
     },
     reason => newAggregateError(reason as Error)
+  );
+}
+
+export function doesPathExistSync(pathToEntity: string): E.Either<Error, string> {
+  return E.tryCatch(
+    () => {
+      const pathExists = fsExtra.pathExistsSync(pathToEntity);
+      if (pathExists) return pathToEntity;
+
+      throw new Error(`Could not find path to ${pathToEntity}`);
+    },
+    reason => reason as Error
   );
 }
 
@@ -140,4 +159,23 @@ export const normalizedCopy = async (src: SourcePath, dest: DestinationPath) =>
 
 export function createDirIfItDoesNotExist(dirPath: string): T.Task<void> {
   return async () => await fsExtra.ensureDir(dirPath);
+}
+
+export function execShellCmd(shellCmd: string, scope: string = '') {
+  const promisifiedExec = promisify(exec)(shellCmd);
+
+  return pipe(
+    getEnv(`${SHELL_EXEC_MOCK_VAR_NAME}${scope}`),
+    O.fold(
+      () => promisifiedExec,
+
+      varValue =>
+        match(varValue)
+          .with(SHELL_EXEC_MOCK_ERROR_HOOK, () =>
+            Promise.reject(new Error(varValue))
+          )
+          .with(P.string, () => Promise.resolve({ stdout: varValue, stderr: '' }))
+          .otherwise(() => promisifiedExec)
+    )
+  );
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,8 +3,8 @@ import * as R from 'fp-ts/lib/Record';
 import * as S from 'fp-ts/lib/string';
 import * as T from 'fp-ts/lib/Task';
 import * as L from 'monocle-ts/Lens';
-import * as MT from 'monocle-ts/Traversal';
 import * as Eq from 'fp-ts/lib/Eq';
+import * as MT from 'monocle-ts/Traversal';
 
 import path from 'path';
 
@@ -137,3 +137,15 @@ const getFileNamesFromConfigGroup = (configGroup: ConfigGroup) =>
 
 export const getFileNamesFromConfigGroups = (configGroups: ConfigGroup[]) =>
   pipe(configGroups, A.chain(getFileNamesFromConfigGroup));
+
+export function normalizeStdout(stdout: string) {
+  const SPACE_DELIMITER = '   ';
+  return pipe(
+    stdout,
+    S.replace(NEW_LINE_CHAR_REGEX, SPACE_DELIMITER),
+    S.trim,
+    S.split(SPACE_DELIMITER)
+  );
+}
+
+export const NEW_LINE_CHAR_REGEX = /\r?\n|\r/g;

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -205,10 +205,11 @@ describe('Tests for the happy path', () => {
       process.env.DOTS = `${LINK_TEST_DATA_DIR}/valid-mock-dots`;
       process.env.DOTFILES = `${LINK_TEST_DATA_DIR}/valid-mock-dots`;
 
-      prompts.inject([true]);
-
       // Act
-      const { errors, forTest: configGroups } = await linkCmd([], mockOptions);
+      const { errors, forTest: configGroups } = await linkCmd(
+        [],
+        mockOptions.concat(['-y'])
+      );
 
       const destinationPaths = getAllDestinationPathsFromConfigGroups(configGroups);
 
@@ -536,7 +537,9 @@ describe('Tests for the happy path', () => {
       const generateConfigGroupEntityPath = generatePath(mockConfigGroupName);
 
       const mockConfigGroupSetupTask = pipe(
-        generateConfigGroupStructurePath(generateConfigGroupEntityPath(nestedDirName)),
+        generateConfigGroupStructurePath(
+          generateConfigGroupEntityPath(nestedDirName)
+        ),
         createDirIfItDoesNotExist
       );
 
@@ -688,7 +691,9 @@ describe('Tests for the happy path', () => {
         const generateConfigGroupEntityPath = generatePath(mockConfigGroupName);
 
         const mockConfigGroupSetupTask = pipe(
-          generateConfigGroupStructurePath(generateConfigGroupEntityPath(nestedDirName)),
+          generateConfigGroupStructurePath(
+            generateConfigGroupEntityPath(nestedDirName)
+          ),
           createDirIfItDoesNotExist
         );
 
@@ -762,7 +767,9 @@ describe('Tests for the happy path', () => {
       const generateConfigGroupEntityPath = generatePath(mockConfigGroupName);
 
       const mockConfigGroupSetupTask = pipe(
-        generateConfigGroupStructurePath(generateConfigGroupEntityPath(nestedDirName)),
+        generateConfigGroupStructurePath(
+          generateConfigGroupEntityPath(nestedDirName)
+        ),
         createDirIfItDoesNotExist
       );
 
@@ -825,7 +832,9 @@ describe('Tests for the happy path', () => {
       const generateConfigGroupEntityPath = generatePath(mockConfigGroupName);
 
       const mockConfigGroupSetupTask = pipe(
-        generateConfigGroupStructurePath(generateConfigGroupEntityPath(nestedDirName)),
+        generateConfigGroupStructurePath(
+          generateConfigGroupEntityPath(nestedDirName)
+        ),
         createDirIfItDoesNotExist
       );
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -68,7 +68,9 @@ describe('Tests for the happy path', () => {
   test('Should ensure that the sync command works as expected given the desired, happy path, inputs', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('new.ts', '')();
-    const { stdout } = await execShellCmd(`ls ${VALID_WORKING_GIT_REPO_DIR_PATH}`);
+    const { stdout } = await execShellCmd(
+      `git -C ${VALID_WORKING_GIT_REPO_DIR_PATH} status --porcelain`
+    );
 
     const defaultCommitMsg = generateDefaultCommitMessage();
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
@@ -101,7 +103,9 @@ describe('Tests for the happy path', () => {
   test('Should ensure that the sync command accepts a custom commit messages', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('update.ts', '')();
-    const { stdout } = await execShellCmd(`ls ${VALID_WORKING_GIT_REPO_DIR_PATH}`);
+    const { stdout } = await execShellCmd(
+      `git -C ${VALID_WORKING_GIT_REPO_DIR_PATH} status --porcelain`
+    );
 
     const customCommitMsg = 'feat: scheduled dotfiles update successful';
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
@@ -134,7 +138,9 @@ describe('Tests for the happy path', () => {
   test('Should ensure that sync command falls back to using default commit message if custom message is empty string', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('another-one.ts', '')();
-    const { stdout } = await execShellCmd(`ls ${VALID_WORKING_GIT_REPO_DIR_PATH}`);
+    const { stdout } = await execShellCmd(
+      `git -C ${VALID_WORKING_GIT_REPO_DIR_PATH} status --porcelain`
+    );
 
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
     const expectedCommitMessage = generateDefaultCommitMessage();

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -20,7 +20,6 @@ import {
   generateGitInstance,
   generateDefaultCommitMessage,
 } from '../src/cmds/sync';
-import { execShellCmd } from '@utils/index';
 
 const SYNC_TEST_DATA_DIR = `${TEST_DATA_DIR_PREFIX}/sync`;
 
@@ -68,16 +67,12 @@ describe('Tests for the happy path', () => {
   test('Should ensure that the sync command works as expected given the desired, happy path, inputs', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('new.ts', '')();
-    const { stdout } = await execShellCmd(
-      `git -C ${VALID_WORKING_GIT_REPO_DIR_PATH} status --porcelain`
-    );
 
     const defaultCommitMsg = generateDefaultCommitMessage();
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
 
     // Act
     const outputVal = await syncCmd([], [])();
-    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH, stdout });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);
@@ -103,16 +98,12 @@ describe('Tests for the happy path', () => {
   test('Should ensure that the sync command accepts a custom commit messages', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('update.ts', '')();
-    const { stdout } = await execShellCmd(
-      `git -C ${VALID_WORKING_GIT_REPO_DIR_PATH} status --porcelain`
-    );
 
     const customCommitMsg = 'feat: scheduled dotfiles update successful';
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
 
     // Act
     const outputVal = await syncCmd([], ['-m', customCommitMsg])();
-    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH, stdout });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);
@@ -138,16 +129,12 @@ describe('Tests for the happy path', () => {
   test('Should ensure that sync command falls back to using default commit message if custom message is empty string', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('another-one.ts', '')();
-    const { stdout } = await execShellCmd(
-      `git -C ${VALID_WORKING_GIT_REPO_DIR_PATH} status --porcelain`
-    );
 
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
     const expectedCommitMessage = generateDefaultCommitMessage();
 
     // Act
     const outputVal = await syncCmd([], ['-m', ''])();
-    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH, stdout });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -20,6 +20,7 @@ import {
   generateGitInstance,
   generateDefaultCommitMessage,
 } from '../src/cmds/sync';
+import { execShellCmd } from '@utils/index';
 
 const SYNC_TEST_DATA_DIR = `${TEST_DATA_DIR_PREFIX}/sync`;
 
@@ -67,13 +68,14 @@ describe('Tests for the happy path', () => {
   test('Should ensure that the sync command works as expected given the desired, happy path, inputs', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('new.ts', '')();
+    const { stdout } = await execShellCmd(`ls ${VALID_WORKING_GIT_REPO_DIR_PATH}`);
 
     const defaultCommitMsg = generateDefaultCommitMessage();
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
 
     // Act
     const outputVal = await syncCmd([], [])();
-    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH });
+    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH, stdout });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);
@@ -99,13 +101,14 @@ describe('Tests for the happy path', () => {
   test('Should ensure that the sync command accepts a custom commit messages', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('update.ts', '')();
+    const { stdout } = await execShellCmd(`ls ${VALID_WORKING_GIT_REPO_DIR_PATH}`);
 
     const customCommitMsg = 'feat: scheduled dotfiles update successful';
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
 
     // Act
     const outputVal = await syncCmd([], ['-m', customCommitMsg])();
-    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH });
+    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH, stdout });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);
@@ -131,13 +134,14 @@ describe('Tests for the happy path', () => {
   test('Should ensure that sync command falls back to using default commit message if custom message is empty string', async () => {
     // Arrange
     await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('another-one.ts', '')();
+    const { stdout } = await execShellCmd(`ls ${VALID_WORKING_GIT_REPO_DIR_PATH}`);
 
     const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
     const expectedCommitMessage = generateDefaultCommitMessage();
 
     // Act
     const outputVal = await syncCmd([], ['-m', ''])();
-    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH });
+    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH, stdout });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -73,6 +73,7 @@ describe('Tests for the happy path', () => {
 
     // Act
     const outputVal = await syncCmd([], [])();
+    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);
@@ -104,6 +105,7 @@ describe('Tests for the happy path', () => {
 
     // Act
     const outputVal = await syncCmd([], ['-m', customCommitMsg])();
+    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);
@@ -135,6 +137,7 @@ describe('Tests for the happy path', () => {
 
     // Act
     const outputVal = await syncCmd([], ['-m', ''])();
+    console.log({ outputVal, VALID_WORKING_GIT_REPO_DIR_PATH });
 
     // Assert
     expect(outputVal).not.toBeInstanceOf(Function);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,0 +1,254 @@
+/* globals expect, describe, test */
+import * as E from 'fp-ts/lib/Either';
+import * as L from 'monocle-ts/Lens';
+
+import { jest } from '@jest/globals';
+import { SimpleGit } from 'simple-git';
+import { createFile } from './helpers';
+import { CmdResponse } from '@types';
+import { identity, pipe } from 'fp-ts/lib/function';
+import { TEST_DATA_DIR_PREFIX } from './setup';
+import {
+  ExitCodes,
+  SHELL_EXEC_MOCK_VAR_NAME,
+  SHELL_EXEC_MOCK_ERROR_HOOK,
+} from '../src/constants';
+import {
+  _main,
+  GitInstance,
+  SYNC_CMD_STATES,
+  generateGitInstance,
+  generateDefaultCommitMessage,
+} from '../src/cmds/sync';
+
+const SYNC_TEST_DATA_DIR = `${TEST_DATA_DIR_PREFIX}/sync`;
+
+const VALID_CLEAN_GIT_REPO_DIR_PATH = `${SYNC_TEST_DATA_DIR}/valid-git-repo-clean`;
+const VALID_WORKING_GIT_REPO_DIR_PATH = `${SYNC_TEST_DATA_DIR}/valid-git-repo-working`;
+
+interface SyncCmd {
+  syncCmd: ReturnType<typeof _main>;
+  mockedSimpleGitInstance: SimpleGit | Error;
+}
+
+function getSyncCmd(
+  dotfilesDirPath: string = VALID_WORKING_GIT_REPO_DIR_PATH
+): SyncCmd {
+  process.env.DOTS = dotfilesDirPath;
+  process.env.DOTFILES = dotfilesDirPath;
+
+  const GitLens = pipe(L.id<GitInstance>(), L.prop('git'));
+
+  const mockedSimpleGitInstance = pipe(
+    generateGitInstance(),
+    E.map(pipe(GitLens, L.modify(mockSimpleGitInstance)))
+  );
+
+  return {
+    mockedSimpleGitInstance: pipe(
+      mockedSimpleGitInstance,
+      E.map(GitLens.get),
+      E.matchW(identity, identity)
+    ),
+    syncCmd: _main(mockedSimpleGitInstance),
+  };
+}
+
+function mockSimpleGitInstance(simpleGitInstance: SimpleGit) {
+  // any castings are used here so I don't need to reimplement the simplegit signature for these methods
+  jest.spyOn(simpleGitInstance, 'add').mockReturnValue(simpleGitInstance as any);
+  jest.spyOn(simpleGitInstance, 'commit').mockReturnValue(simpleGitInstance as any);
+  jest.spyOn(simpleGitInstance, 'push').mockReturnValue(simpleGitInstance as any);
+
+  return simpleGitInstance;
+}
+
+describe('Tests for the happy path', () => {
+  test('Should ensure that the sync command works as expected given the desired, happy path, inputs', async () => {
+    // Arrange
+    await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('new.ts', '')();
+
+    const defaultCommitMsg = generateDefaultCommitMessage();
+    const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
+
+    // Act
+    const outputVal = await syncCmd([], [])();
+
+    // Assert
+    expect(outputVal).not.toBeInstanceOf(Function);
+    expect(mockedSimpleGitInstance).not.toBeInstanceOf(Error);
+
+    expect((mockedSimpleGitInstance as SimpleGit).push).toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).commit).toHaveBeenCalledWith(
+      defaultCommitMsg
+    );
+    expect((mockedSimpleGitInstance as SimpleGit).add).toHaveBeenCalledWith([
+      VALID_WORKING_GIT_REPO_DIR_PATH,
+      '--all',
+    ]);
+
+    expect(outputVal as CmdResponse<string>).toMatchObject<CmdResponse<string>>({
+      errors: [],
+      warnings: [],
+      forTest: '',
+      output: [defaultCommitMsg],
+    });
+  });
+
+  test('Should ensure that the sync command accepts a custom commit messages', async () => {
+    // Arrange
+    await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('update.ts', '')();
+
+    const customCommitMsg = 'feat: scheduled dotfiles update successful';
+    const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
+
+    // Act
+    const outputVal = await syncCmd([], ['-m', customCommitMsg])();
+
+    // Assert
+    expect(outputVal).not.toBeInstanceOf(Function);
+    expect(mockedSimpleGitInstance).not.toBeInstanceOf(Error);
+
+    expect((mockedSimpleGitInstance as SimpleGit).push).toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).commit).toHaveBeenCalledWith(
+      customCommitMsg
+    );
+    expect((mockedSimpleGitInstance as SimpleGit).add).toHaveBeenCalledWith([
+      VALID_WORKING_GIT_REPO_DIR_PATH,
+      '--all',
+    ]);
+
+    expect(outputVal as CmdResponse<string>).toMatchObject<CmdResponse<string>>({
+      errors: [],
+      warnings: [],
+      forTest: '',
+      output: [customCommitMsg],
+    });
+  });
+
+  test('Should ensure that sync command falls back to using default commit message if custom message is empty string', async () => {
+    // Arrange
+    await createFile(VALID_WORKING_GIT_REPO_DIR_PATH)('another-one.ts', '')();
+
+    const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
+    const expectedCommitMessage = generateDefaultCommitMessage();
+
+    // Act
+    const outputVal = await syncCmd([], ['-m', ''])();
+
+    // Assert
+    expect(outputVal).not.toBeInstanceOf(Function);
+    expect(mockedSimpleGitInstance).not.toBeInstanceOf(Error);
+
+    expect((mockedSimpleGitInstance as SimpleGit).push).toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).commit).toHaveBeenCalledWith(
+      expectedCommitMessage
+    );
+    expect((mockedSimpleGitInstance as SimpleGit).add).toHaveBeenCalledWith([
+      VALID_WORKING_GIT_REPO_DIR_PATH,
+      '--all',
+    ]);
+
+    expect(outputVal as CmdResponse<string>).toMatchObject<CmdResponse<string>>({
+      errors: [],
+      warnings: [],
+      forTest: '',
+      output: [expectedCommitMessage],
+    });
+  });
+
+  test('Should ensure that the sync command exits early (and successfully) should there be no changes in the dotfiles repo', async () => {
+    // Arrange
+    const { syncCmd, mockedSimpleGitInstance } = getSyncCmd(
+      VALID_CLEAN_GIT_REPO_DIR_PATH
+    );
+
+    // Act
+    const outputVal = await syncCmd([], ['-m', ''])();
+
+    // Assert
+    expect(outputVal).not.toBeInstanceOf(Function);
+    expect(mockedSimpleGitInstance).not.toBeInstanceOf(Error);
+
+    expect((mockedSimpleGitInstance as SimpleGit).push).not.toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).commit).not.toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).add).not.toHaveBeenCalled();
+
+    expect(outputVal as CmdResponse<string>).toMatchObject<CmdResponse<string>>({
+      errors: [],
+      warnings: [],
+      forTest: '',
+      output: [SYNC_CMD_STATES.DOTFILES_DIR_HAS_NO_CHANGES],
+    });
+  });
+});
+
+describe('Tests for everything but the happy path', () => {
+  test('Should ensure the sync command exits if the dotfiles directory is invalid', async () => {
+    // Arrange
+    const { syncCmd, mockedSimpleGitInstance } = getSyncCmd(
+      `${SYNC_TEST_DATA_DIR}/random-dir`
+    );
+
+    // Act
+    const outputVal = await syncCmd([], [])();
+    (outputVal as Function)(); // We expect output to be of type IO<never>
+
+    // Assert
+    expect(outputVal).toBeInstanceOf(Function);
+    expect(process.exit).toHaveBeenCalledWith(ExitCodes.GENERAL);
+    expect(mockedSimpleGitInstance).toBeInstanceOf(Error);
+  });
+
+  test('Should ensure that the sync command exits if dotfiles directory is not a git repository', async () => {
+    // Arrange
+    process.env[`${SHELL_EXEC_MOCK_VAR_NAME}forGitRepoCheck`] =
+      SHELL_EXEC_MOCK_ERROR_HOOK;
+
+    const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
+
+    // Act
+    const outputVal = await syncCmd([], [])();
+
+    // Assert
+    expect(outputVal).not.toBeInstanceOf(Function);
+    expect(mockedSimpleGitInstance).not.toBeInstanceOf(Error);
+
+    expect((mockedSimpleGitInstance as SimpleGit).push).not.toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).commit).not.toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).add).not.toHaveBeenCalled();
+
+    expect(outputVal as CmdResponse<string>).toMatchObject<CmdResponse<string>>({
+      errors: [SYNC_CMD_STATES.DOTFILES_DIR_IS_NOT_GIT_REPO],
+      warnings: [],
+      forTest: '',
+      output: [],
+    });
+  });
+
+  test('Should ensure that the sync command exits gracefully if git is not installed?', async () => {
+    // Arrange
+    process.env[`${SHELL_EXEC_MOCK_VAR_NAME}forGitCheck`] =
+      SHELL_EXEC_MOCK_ERROR_HOOK;
+
+    const { syncCmd, mockedSimpleGitInstance } = getSyncCmd();
+
+    // Act
+    const outputVal = await syncCmd([], [])();
+
+    // Assert
+    expect(outputVal).not.toBeInstanceOf(Function);
+    expect(mockedSimpleGitInstance).not.toBeInstanceOf(Error);
+
+    expect((mockedSimpleGitInstance as SimpleGit).push).not.toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).commit).not.toHaveBeenCalled();
+    expect((mockedSimpleGitInstance as SimpleGit).add).not.toHaveBeenCalled();
+
+    expect(outputVal as CmdResponse<string>).toMatchObject<CmdResponse<string>>({
+      errors: [SYNC_CMD_STATES.GIT_IS_NOT_INSTALLED],
+      warnings: [],
+      forTest: '',
+      output: [],
+    });
+  });
+});

--- a/tests/unlink.test.ts
+++ b/tests/unlink.test.ts
@@ -5,7 +5,6 @@ import * as S from 'fp-ts/lib/string';
 import * as T from 'fp-ts/lib/Task';
 
 import path from 'path';
-import prompts from 'prompts';
 
 import { compose } from 'ramda';
 import { flow, pipe } from 'fp-ts/lib/function';
@@ -77,15 +76,19 @@ describe('Tests for the happy path', () => {
       process.env.DOTS = `${UNLINK_TEST_DATA_DIR}/valid-mock-dots`;
       process.env.DOTFILES = `${UNLINK_TEST_DATA_DIR}/valid-mock-dots`;
 
-      prompts.inject([true, true]);
-
-      const { forTest: configGroups } = await linkCmd([], mockOptions);
+      const { forTest: configGroups } = await linkCmd(
+        [],
+        mockOptions.concat(['-y'])
+      );
 
       const linkCmdDestinationPaths =
         getAllDestinationPathsFromConfigGroups(configGroups);
 
       // Act
-      const { errors, forTest: operatedOnDestinationPaths } = await unlinkCmd([]);
+      const { errors, forTest: operatedOnDestinationPaths } = await unlinkCmd(
+        [],
+        ['--yes']
+      );
 
       const areAllDestinationFilesPresentAtTheirDestinationPaths =
         await checkIfAllPathsAreValid(operatedOnDestinationPaths)();


### PR DESCRIPTION
- Sync command is feature complete and tested

- Testing shell command execution was very tricky, but I was able to overcome it by using an environment variable to augment the shell command executor function. Though this worked, it only did so for the first invocation of the function. I wanted a solution that would work for all invocations which lead me to use scopes. using scopes I am able to differentiate the value of the augmenting environment variable between invocations and thus, mock each invocation separately should I want to

- Created an abstraction to make parsing command options easier with less boilerplate
    
- (WIP) improving command function interface and types. Attempting to keep the purity going as long as possible
    
- Fixed some minor type issues
    
- Created script for bootstrapping sync tests mock data

- Added '--yes' option to override prompt for `link` and `unlink` command
    
- Updated tests to utilize '-y' option instead of the `inject` API on the prompts library

- Now the link and unlink commands can be run without interruption from a prompt

- built a general-purpose CLI options parser with fp-ts

- Added tests to ensure correctness and applicability

- Original parser `minimal-argp` was limited in functionality as it could only handle flags, but `arg-parser` is flexible enough to cater to most types of options

- With this new lib, I will need to update all usage of `minimal-argp` with this one and deprecate the `minimal-argp`

- Written with fp-ts making it compatible with the rest of the CLI