### PR TITLE
fix(ci): Added fallback to native sed command in patch script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,12 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Test
-        run: npm run test:ci
+      - name: Run tests
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "<>"
+          git config --global init.defaultBranch main
+          npm run test:ci
 
       - name: Build
         run: npm run build

--- a/dist-patch.sh
+++ b/dist-patch.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 
-if ! command -v sd &>/dev/null; then
-  echo "sd (https://github.com/chmln/sd) is required to run this script. Please install it"
-  exit 1
-fi
-
 set -o errexit
 
-# These commands patch up the imports of the compiled source to allow
-# these CJS modules to be accessed in an ESM evironment
 echo "Fixing up fp-ts, io-ts, and monocle-ts imports..."
-grep -rl ./dist -e "fp-ts" | xargs -I _ sd "\b(fp-ts(.*))\b" '$1.js' _
-grep -rl ./dist -e "io-ts" | xargs -I _ sd "\b(io-ts(.*))\b" '$1.js' _
-grep -rl ./dist -e "monocle-ts" | xargs -I _ sd "\b(monocle-ts(.*))\b" '$1.js' _
+
+if command -v sd &>/dev/null; then
+  # These commands patch up the imports of the compiled source to allow
+  # these CJS modules to be accessed in an ESM evironment
+  grep -rl ./dist -e "fp-ts" | xargs -I _ sd "\b(fp-ts(.*))\b" '$1.js' _
+  grep -rl ./dist -e "io-ts" | xargs -I _ sd "\b(io-ts(.*))\b" '$1.js' _
+  grep -rl ./dist -e "monocle-ts" | xargs -I _ sd "\b(monocle-ts(.*))\b" '$1.js' _
+else
+  echo "sd (https://github.com/chmln/sd) is not installed, switching to sed..."
+  grep -rl ./dist -e "fp-ts" | xargs -I _ sed -i -E "s#\b(fp-ts(.*))\b#\1.js#g" _
+  grep -rl ./dist -e "io-ts" | xargs -I _ sed -i -E "s#\b(io-ts(.*))\b#\1.js#g" _
+  grep -rl ./dist -e "monocle-ts" | xargs -I _ sed -i -E "s#\b(monocle-ts(.*))\b#\1.js#g" _
+fi
+
 echo "Done!"


### PR DESCRIPTION
- Release CI was broken because the `sd` package was not installed in host environment. Upon further investigation, it looks like the package is not available in the registry (Ubuntu) of the CI host environment so a fallback to the native sed command was added