### PR TITLE
fix: Fixed some initial release bugs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,7 +46,10 @@ module.exports = {
     ],
 
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' },
+    ],
 
     'import/prefer-default-export': 0,
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,7 +17,10 @@ if (isCI) {
   testPathIgnorePatterns = defaults.testPathIgnorePatterns;
 }
 
-testPathIgnorePatterns = testPathIgnorePatterns.concat(['/tests/test-data/']);
+testPathIgnorePatterns = testPathIgnorePatterns.concat([
+  '/tests/test-data/',
+  'src/lib/minimal-argp',
+]);
 
 const config: JestConfigWithTsJest = {
   preset: 'ts-jest/presets/default-esm',

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -65,12 +65,17 @@ export default function generateCmdHandlerFn(
   };
 }
 
-export function getCliCommand(cliInputs: CliInputs) {
+export function getCliCommand(rawCliInputs: CliInputs) {
   return pipe(
-    cliInputs,
+    rawCliInputs,
     A.head,
     O.getOrElseW(() => 'no command')
   ) as CommandsAndAliases;
+}
+
+export function getCliInputsForCmd(rawCliInputs: string[]) {
+  const [_, ...restOfInputs] = rawCliInputs;
+  return restOfInputs as CliInputs;
 }
 
 function handleBadCommand(badCommand: string) {

--- a/src/app/configGroup.ts
+++ b/src/app/configGroup.ts
@@ -392,4 +392,4 @@ export function isNotIgnored(fileObj: File): boolean {
   return fileObj.ignore === false;
 }
 
-export const DEFAULT_DEST_RECORD_FILE_CONTENTS = { '!': '*' };
+export const DEFAULT_DEST_RECORD_FILE_CONTENTS = { [EXCLUDE_KEY]: ALL_FILES_CHAR };

--- a/src/cmds/link.ts
+++ b/src/cmds/link.ts
@@ -24,6 +24,7 @@ import {
   deleteThenSymlink,
   deleteThenHardlink,
   createDirIfItDoesNotExist,
+  indentText,
 } from '@utils/index';
 import {
   exitCli,
@@ -149,12 +150,18 @@ function aggregateCmdErrors(errors: ExitCodes.OK | Error) {
 function initiateSpinner(configGroupNamesOrDirPaths: string[]) {
   const configGroupsNames = pipe(configGroupNamesOrDirPaths, A.map(path.basename));
 
-  return () =>
-    spinner.start(
+  return () => {
+    // For a prettier output
+    console.log('\n');
+
+    return pipe(
       `Linking files from the following config groups: ${arrayToList(
         configGroupsNames
-      )}...`
+      )}...`,
+      indentText(),
+      spinner.start.bind(spinner)
     );
+  };
 }
 
 interface LinkOperationResponse {
@@ -295,9 +302,13 @@ function matchDesiredLinkOperation(linkOperationType: LinkCmdOperationType) {
 }
 
 function stopSpinnerOnSuccess() {
-  return spinner.succeed('Linking complete!');
+  return pipe('Linking complete!', indentText(), spinner.succeed.bind(spinner));
 }
 
 function stopSpinnerOnError() {
-  return spinner.succeed('Linking failed. Exiting...');
+  return pipe(
+    'Linking failed. Exiting...',
+    indentText(),
+    spinner.fail.bind(spinner)
+  );
 }

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -11,7 +11,7 @@ import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { newAggregateError } from '@utils/AggregateError';
 import { ExitCodes, spinner } from '../constants';
 import { optionConfigConstructor } from '@lib/arg-parser';
-import { doesPathExistSync, execShellCmd } from '../utils/index';
+import { doesPathExistSync, execShellCmd, indentText } from '../utils/index';
 import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
 import {
   CmdOptions,
@@ -59,7 +59,16 @@ export function _main(gitInstance: E.Either<Error, GitInstance>) {
 }
 
 function initiateSpinner() {
-  return () => spinner.start('Syncing dotfiles changes...');
+  return () => {
+    // For a prettier output
+    console.log('\n');
+
+    return pipe(
+      'Syncing dotfiles changes...',
+      indentText(),
+      spinner.start.bind(spinner)
+    );
+  };
 }
 
 // EXPORTED FOR TESTING PURPOSES ONLY
@@ -126,7 +135,6 @@ function syncCmd(git: SimpleGit) {
       TE.fold(
         syncErrorStateMsg => async () =>
           constructSyncCmdErrorResponse(syncErrorStateMsg),
-
         handleSyncSuccessOutput(git)(dotfilesDirPath)(cmdOptions)
       )
     )();
@@ -260,11 +268,11 @@ export function generateDefaultCommitMessage() {
 }
 
 function stopSpinnerOnSuccess() {
-  return spinner.succeed('Sync complete!');
+  return pipe('Sync complete!', indentText(), spinner.succeed.bind(spinner));
 }
 
 function stopSpinnerOnError() {
-  return spinner.succeed('Sync failed. Exiting...');
+  return pipe('Sync failed. Exiting...', indentText(), spinner.fail.bind(spinner));
 }
 
 const main = () => _main(generateGitInstance());

--- a/src/cmds/unlink.ts
+++ b/src/cmds/unlink.ts
@@ -12,7 +12,7 @@ import { match, P } from 'ts-pattern';
 import { ExitCodes, spinner } from '../constants';
 import { pipe, flow, constTrue } from 'fp-ts/lib/function';
 import { optionConfigConstructor } from '@lib/arg-parser';
-import { arrayToList, bind, removeEntityAt } from '@utils/index';
+import { arrayToList, bind, indentText, removeEntityAt } from '@utils/index';
 import {
   isNotIgnored,
   getFilesFromConfigGroup,
@@ -119,12 +119,18 @@ function aggregateCmdErrors(errors: ExitCodes.OK | Error) {
 function initiateSpinner(configGroupNamesOrDirPaths: string[]) {
   const configGroupsNames = pipe(configGroupNamesOrDirPaths, A.map(path.basename));
 
-  return () =>
-    spinner.start(
+  return () => {
+    // For a prettier output
+    console.log('\n');
+
+    return pipe(
       `Unlinking files from the following config groups: ${arrayToList(
         configGroupsNames
-      )}...`
+      )}...`,
+      indentText(),
+      spinner.start.bind(spinner)
     );
+  };
 }
 
 interface UnlinkOperationResponse {
@@ -215,11 +221,17 @@ function undoOperationPerformedByLinkCmd(destinationPaths: string[]) {
 }
 
 function stopSpinnerOnSuccess() {
-  return spinner.succeed('Unlinked config group files from their destinations');
+  return pipe(
+    'Unlinked config group files from their destinations',
+    indentText(),
+    spinner.succeed.bind(spinner)
+  );
 }
 
 function stopSpinnerOnError() {
-  return spinner.succeed(
-    'Failed to remove config group files from their destinations. Exiting...'
+  return pipe(
+    'Failed to remove config group files from their destinations. Exiting...',
+    indentText(),
+    spinner.fail.bind(spinner)
   );
 }

--- a/src/lib/arg-parser/test.ts
+++ b/src/lib/arg-parser/test.ts
@@ -24,6 +24,9 @@ test('Should ensure that CLI argument parser works as intended ', () => {
 
   const sampleArgv = [
     ...expectedPositionalArgs,
+    // This was added to test if the arg-parser is smart enough to NOT consider the values of unknown options as positional args
+    '-i',
+    'jjjj',
     '--many=8',
     '-ab',
     ...expectedUnknownOptions,
@@ -69,7 +72,7 @@ test('Should ensure that CLI argument parser works as intended ', () => {
   // Assert
   expect(options).toMatchObject(pipe(expectedOptions, R.map(O.some)));
   expect(positionalArgs).toIncludeSameMembers(expectedPositionalArgs);
-  expect(unknownOptions).toIncludeSameMembers(expectedUnknownOptions);
+  expect(unknownOptions).toIncludeSameMembers(expectedUnknownOptions.concat(['-i']));
 });
 
 test('Should ensure parser can handle options that are not present in argv but have been specified in config without a default value', () => {

--- a/src/lib/minimal-argp/index.ts
+++ b/src/lib/minimal-argp/index.ts
@@ -1,11 +1,2 @@
-import ArgParser from './src/index';
-import { ParserParams } from './src/types';
-
-export default function parseCliArgs<ParserInput extends ParserParams>(
-  parserConfig: ParserInput
-) {
-  return (args: string[]) => new ArgParser<ParserInput>(parserConfig).parse(args);
-}
-
-export { ArgParser };
-export type { ParserParams };
+// This lib is deprecated
+export {};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -123,7 +123,7 @@ export function logErrors(errorMsgs: string[]): IO.IO<void> {
       'Errors'
     )}(${chalk[LogColor.ERROR].dim.underline(errorMsgs.length)})`;
 
-    console.warn('\n');
+    console.error('\n');
     console.error(title);
     console.error(errStr);
   };
@@ -302,4 +302,8 @@ export function removeLeadingPathSeparator(
     strWithLeadingPathSeparator,
     S.replace(LEADING_PATH_SEPARATOR_REGEX, '')
   );
+}
+
+export function indentText(indentSize: number = 17) {
+  return (text: string) => text.trim().padStart(indentSize);
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -12,6 +12,7 @@ import fsExtra from 'fs-extra';
 import { values } from 'ramda';
 import { MonoidAll } from 'fp-ts/lib/boolean';
 import { concatAll } from 'fp-ts/lib/Monoid';
+import { EXCLUDE_KEY } from '../src/constants';
 import { flow, identity, pipe } from 'fp-ts/lib/function';
 import { lstat, stat, writeFile } from 'fs/promises';
 import { AnyFunction, ConfigGroup, DestinationPath, File, SourcePath } from '@types';
@@ -68,7 +69,7 @@ export const manualFail = (v: any) => {
 };
 
 export const defaultDestRecordEq = Eq.struct({
-  '!': S.Eq,
+  [EXCLUDE_KEY]: S.Eq,
 });
 
 export function createFile(rootPath: string) {


### PR DESCRIPTION
- Fixed issue where commands weren't receiving CLI inputs
- Fixed issue where interactive mode was always causing CLI to exit with status code of 0
- Modified some eslint rules
- Improved log output formatting
- Fixed issue where CLI spinner errors were treated as successes
- Fixed issue with wrong default destination map file being used on create command